### PR TITLE
ignore throwables in StartupHook, reordered db.changelog-0.25.0.xml f…

### DIFF
--- a/data/changelog/db.changelog-0.25.0.xml
+++ b/data/changelog/db.changelog-0.25.0.xml
@@ -22,16 +22,6 @@
             <column name="date_completed" type="datetime"/>
         </createTable>
         <addPrimaryKey columnNames="guid" constraintName="PRIMARY" tableName="dataset"/>
-
-        <addForeignKeyConstraint baseColumnNames="package_guid" baseTableName="dataset" constraintName="fk_dataset_content_package_guid" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="guid" referencedTableName="content_package"/>
-        <createIndex indexName="fk_dataset_content_package_guid" tableName="dataset">
-            <column name="package_guid"/>
-        </createIndex>
-
-        <addForeignKeyConstraint baseColumnNames="dataset_blob_guid" baseTableName="dataset" constraintName="fk_dataset_dataset_blob_guid" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="guid" referencedTableName="dataset_blob"/>
-        <createIndex indexName="fk_dataset_dataset_blob_guid" tableName="dataset">
-            <column name="dataset_blob_guid"/>
-        </createIndex>
     </changeSet>
 
     <!-- Dataset blob table -->
@@ -62,10 +52,41 @@
         <addColumn tableName="content_package">
             <column name="active_dataset_guid" type="VARCHAR(32)"/>
         </addColumn>
-        <addForeignKeyConstraint baseColumnNames="active_dataset_guid" baseTableName="content_package" constraintName="fk_content_package_dataset_guid" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="guid" referencedTableName="dataset"/>
+
+    </changeSet>
+
+    <changeSet author="rgachuhi@cmu.edu" id="0.25.0-4">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <foreignKeyConstraintExists foreignKeyName="fk_dataset_content_package_guid" foreignKeyTableName="dataset"/>
+            </not>
+        </preConditions>
+        <createIndex indexName="fk_dataset_content_package_guid" tableName="dataset">
+            <column name="package_guid"/>
+        </createIndex>
+        <addForeignKeyConstraint baseColumnNames="package_guid" baseTableName="dataset" constraintName="fk_dataset_content_package_guid" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="guid" referencedTableName="content_package"/>
+    </changeSet>
+    <changeSet author="rgachuhi@cmu.edu" id="0.25.0-5">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <foreignKeyConstraintExists foreignKeyName="fk_dataset_dataset_blob_guid" foreignKeyTableName="dataset"/>
+            </not>
+        </preConditions>
+        <createIndex indexName="fk_dataset_dataset_blob_guid" tableName="dataset">
+            <column name="dataset_blob_guid"/>
+        </createIndex>
+        <addForeignKeyConstraint baseColumnNames="dataset_blob_guid" baseTableName="dataset" constraintName="fk_dataset_dataset_blob_guid" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="guid" referencedTableName="dataset_blob"/>
+    </changeSet>
+    <changeSet author="rgachuhi@cmu.edu" id="0.25.0-6">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <foreignKeyConstraintExists foreignKeyName="fk_content_package_dataset_guid" foreignKeyTableName="content_package"/>
+            </not>
+        </preConditions>
         <createIndex indexName="fk_content_package_dataset_guid" tableName="content_package">
             <column name="active_dataset_guid"/>
         </createIndex>
+        <addForeignKeyConstraint baseColumnNames="active_dataset_guid" baseTableName="content_package" constraintName="fk_content_package_dataset_guid" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="guid" referencedTableName="dataset"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '3.1'
 services:
-  content:
+  authoring-server:
     build: .
-    image: oli/content-service
-    container_name: content-service
+    image: oli/authoring-server
+    container_name: authoring-server
     env_file: service.envs
     environment:
       - MYSQL_ADDRESS=mysql-content
@@ -14,7 +14,7 @@ services:
       - /oli_content/course_content_xml:/oli/course_content_xml
       - /oli/service_config:/oli/service_config
     networks:
-      - content-tier
+      - authoring-server-tier
     depends_on:
       - mysql-content
   mysql-content:
@@ -23,7 +23,7 @@ services:
     ports:
       - "33382:3306"
     networks:
-      - content-tier
+      - authoring-server-tier
 networks:
-  content-tier:
+  authoring-server-tier:
     driver: bridge

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.cmu.oli</groupId>
-    <artifactId>content-service</artifactId>
+    <artifactId>authoring-server</artifactId>
     <version>0.1.0</version>
     <packaging>war</packaging>
     <dependencyManagement>

--- a/src/main/java/edu/cmu/oli/content/contentfiles/StartupHook.java
+++ b/src/main/java/edu/cmu/oli/content/contentfiles/StartupHook.java
@@ -25,9 +25,14 @@ public class StartupHook {
 
     // Reset any datasets that are in the PROCESSING state to the FAILED state.
     private void resetDatasets() {
-        final Query q = em.createNamedQuery("Dataset.resetProcessing");
-        q.executeUpdate();
-        log.info("Reset PROCESSING datasets to FAILED");
+        try {
+            final Query q = em.createNamedQuery("Dataset.resetProcessing");
+            q.executeUpdate();
+            log.info("Reset PROCESSING datasets to FAILED");
+        }catch (Throwable e){
+            log.info(e.getLocalizedMessage());
+        }
+
     }
 
     public void init(@Observes @Initialized(ApplicationScoped.class) Object init) {


### PR DESCRIPTION
This PR fixes Liquibase foreign key creation attempt before referenced table and StartupHook failure on clean db startup due to missing dataset table.




RISK: Medium