### PR TITLE
Cloned packages should create datasets from previous versions of cloned-from packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Open Learning Initiative](https://oli.cmu.edu/wp-content/uploads/2018/10/oli-logo-78px-high-1.svg)](http://oli.cmu.edu/)
 
-[![Build Status](https://dalaran.oli.cmu.edu/jenkins/buildStatus/icon?job=content-service)](https://dalaran.oli.cmu.edu/jenkins/job/content-service/)
-[![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/Simon-Initiative/course-editor/blob/master/LICENSE)
+[![Build Status](https://dalaran.oli.cmu.edu/jenkins/buildStatus/icon?job=authoring-server)](https://dalaran.oli.cmu.edu/jenkins/job/authoring-server/)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/Simon-Initiative/authoring-server/blob/master/LICENSE)
 
 Java EE OLI Content Service Maven project
 

--- a/data/changelog/db.changelog-0.25.0.xml
+++ b/data/changelog/db.changelog-0.25.0.xml
@@ -22,16 +22,6 @@
             <column name="date_completed" type="datetime"/>
         </createTable>
         <addPrimaryKey columnNames="guid" constraintName="PRIMARY" tableName="dataset"/>
-
-        <addForeignKeyConstraint baseColumnNames="package_guid" baseTableName="dataset" constraintName="fk_dataset_content_package_guid" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="guid" referencedTableName="content_package"/>
-        <createIndex indexName="fk_dataset_content_package_guid" tableName="dataset">
-            <column name="package_guid"/>
-        </createIndex>
-
-        <addForeignKeyConstraint baseColumnNames="dataset_blob_guid" baseTableName="dataset" constraintName="fk_dataset_dataset_blob_guid" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="guid" referencedTableName="dataset_blob"/>
-        <createIndex indexName="fk_dataset_dataset_blob_guid" tableName="dataset">
-            <column name="dataset_blob_guid"/>
-        </createIndex>
     </changeSet>
 
     <!-- Dataset blob table -->
@@ -62,10 +52,41 @@
         <addColumn tableName="content_package">
             <column name="active_dataset_guid" type="VARCHAR(32)"/>
         </addColumn>
-        <addForeignKeyConstraint baseColumnNames="active_dataset_guid" baseTableName="content_package" constraintName="fk_content_package_dataset_guid" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="guid" referencedTableName="dataset"/>
+
+    </changeSet>
+
+    <changeSet author="rgachuhi@cmu.edu" id="0.25.0-4">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <foreignKeyConstraintExists foreignKeyName="fk_dataset_content_package_guid" foreignKeyTableName="dataset"/>
+            </not>
+        </preConditions>
+        <createIndex indexName="fk_dataset_content_package_guid" tableName="dataset">
+            <column name="package_guid"/>
+        </createIndex>
+        <addForeignKeyConstraint baseColumnNames="package_guid" baseTableName="dataset" constraintName="fk_dataset_content_package_guid" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="guid" referencedTableName="content_package"/>
+    </changeSet>
+    <changeSet author="rgachuhi@cmu.edu" id="0.25.0-5">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <foreignKeyConstraintExists foreignKeyName="fk_dataset_dataset_blob_guid" foreignKeyTableName="dataset"/>
+            </not>
+        </preConditions>
+        <createIndex indexName="fk_dataset_dataset_blob_guid" tableName="dataset">
+            <column name="dataset_blob_guid"/>
+        </createIndex>
+        <addForeignKeyConstraint baseColumnNames="dataset_blob_guid" baseTableName="dataset" constraintName="fk_dataset_dataset_blob_guid" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="guid" referencedTableName="dataset_blob"/>
+    </changeSet>
+    <changeSet author="rgachuhi@cmu.edu" id="0.25.0-6">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <foreignKeyConstraintExists foreignKeyName="fk_content_package_dataset_guid" foreignKeyTableName="content_package"/>
+            </not>
+        </preConditions>
         <createIndex indexName="fk_content_package_dataset_guid" tableName="content_package">
             <column name="active_dataset_guid"/>
         </createIndex>
+        <addForeignKeyConstraint baseColumnNames="active_dataset_guid" baseTableName="content_package" constraintName="fk_content_package_dataset_guid" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="guid" referencedTableName="dataset"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '3.1'
 services:
-  content:
+  authoring-server:
     build: .
-    image: oli/content-service
-    container_name: content-service
+    image: oli/authoring-server
+    container_name: authoring-server
     env_file: service.envs
     environment:
       - MYSQL_ADDRESS=mysql-content
@@ -14,7 +14,7 @@ services:
       - /oli_content/course_content_xml:/oli/course_content_xml
       - /oli/service_config:/oli/service_config
     networks:
-      - content-tier
+      - authoring-server-tier
     depends_on:
       - mysql-content
   mysql-content:
@@ -23,7 +23,7 @@ services:
     ports:
       - "33382:3306"
     networks:
-      - content-tier
+      - authoring-server-tier
 networks:
-  content-tier:
+  authoring-server-tier:
     driver: bridge

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.cmu.oli</groupId>
-    <artifactId>content-service</artifactId>
+    <artifactId>authoring-server</artifactId>
     <version>0.1.0</version>
     <packaging>war</packaging>
     <dependencyManagement>

--- a/src/main/java/edu/cmu/oli/content/analytics/DatasetBuilder.java
+++ b/src/main/java/edu/cmu/oli/content/analytics/DatasetBuilder.java
@@ -37,12 +37,14 @@ import edu.cmu.oli.content.models.persistance.entities.DatasetBlob;
 import edu.cmu.oli.content.models.persistance.entities.DatasetStatus;
 import edu.cmu.oli.content.reportingdb.DbConnector;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.persistence.Tuple;
 
 import edu.cmu.oli.content.ResourceException;
 import javax.ws.rs.core.Response;
@@ -148,35 +150,39 @@ public class DatasetBuilder {
      * versions of that package, and "parents" of the package if it was cloned.
      */
     private List<String> getPackages(final Dataset dataset) throws SQLException {
-        ContentPackage contentPackage = dataset.getContentPackage();
-
-        List<String> packageGuids = new ArrayList<String>();
-        // First preference is to use data from the dataset package itself
-        packageGuids.add(contentPackage.getGuid());
-
-        Map<String, String> variableReplacements = new HashMap<>();
-        variableReplacements.put("packageId", toSqlString(contentPackage.getId()));
-        variableReplacements.put("packageGuid", toSqlString(contentPackage.getGuid()));
-        String query = parseQuery(findPackagesQuery, variableReplacements);
-
-        // This blocks until the db returns results
-        JsonArray results = db.readDatabase(query);
-        log.info("Received packages from db: " + results.toString());
-
-        // Query returns packages ordered from newest to oldest. Results are in the form
-        // [{ "guid": "234587878753827" }]
-        for (JsonElement result : results) {
-            packageGuids.add(result.getAsJsonObject().get("guid").getAsString());
-        }
+        ContentPackage datasetPackage = dataset.getContentPackage();
+        List<ContentPackage> packagesToQuery = new ArrayList<>();
+        packagesToQuery.add(datasetPackage);
 
         // If this course has been cloned, there may be no previous versions of the
         // course with data, so we also consider package parents created before the
         // date this course was cloned.
-        String parentGuid = contentPackage.getParentPackage();
+        String parentGuid = datasetPackage.getParentPackage();
         while (parentGuid != null) {
-            packageGuids.add(parentGuid);
             ContentPackage parent = findContentPackage(parentGuid);
+            packagesToQuery.add(parent);
             parentGuid = parent.getParentPackage();
+        }
+        // Sort packages from newest to oldest
+        packagesToQuery.sort((ContentPackage a, ContentPackage b) -> b.getDateCreated().compareTo(a.getDateCreated()));
+
+        List<String> packageGuids = new ArrayList<String>();
+
+        for (ContentPackage contentPackage : packagesToQuery) {
+            Map<String, String> variableReplacements = new HashMap<>();
+            variableReplacements.put("packageId", toSqlString(contentPackage.getId()));
+            variableReplacements.put("packageGuid", toSqlString(contentPackage.getGuid()));
+            String query = parseQuery(findPackagesQuery, variableReplacements);
+
+            // DB queries run synchronously
+            JsonArray results = db.readDatabase(query);
+            log.info("Received packages from db: " + results.toString());
+
+            // Query returns package versions ordered from newest to oldest. Results are in
+            // the form [{ "guid": "234587878753827" }]
+            for (JsonElement result : results) {
+                packageGuids.add(result.getAsJsonObject().get("guid").getAsString());
+            }
         }
 
         return packageGuids;

--- a/src/main/java/edu/cmu/oli/content/analytics/DatasetBuilder.java
+++ b/src/main/java/edu/cmu/oli/content/analytics/DatasetBuilder.java
@@ -37,14 +37,12 @@ import edu.cmu.oli.content.models.persistance.entities.DatasetBlob;
 import edu.cmu.oli.content.models.persistance.entities.DatasetStatus;
 import edu.cmu.oli.content.reportingdb.DbConnector;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import javax.persistence.Tuple;
 
 import edu.cmu.oli.content.ResourceException;
 import javax.ws.rs.core.Response;

--- a/src/main/java/edu/cmu/oli/content/contentfiles/StartupHook.java
+++ b/src/main/java/edu/cmu/oli/content/contentfiles/StartupHook.java
@@ -25,9 +25,14 @@ public class StartupHook {
 
     // Reset any datasets that are in the PROCESSING state to the FAILED state.
     private void resetDatasets() {
-        final Query q = em.createNamedQuery("Dataset.resetProcessing");
-        q.executeUpdate();
-        log.info("Reset PROCESSING datasets to FAILED");
+        try {
+            final Query q = em.createNamedQuery("Dataset.resetProcessing");
+            q.executeUpdate();
+            log.info("Reset PROCESSING datasets to FAILED");
+        }catch (Throwable e){
+            log.info(e.getLocalizedMessage());
+        }
+
     }
 
     public void init(@Observes @Initialized(ApplicationScoped.class) Object init) {

--- a/src/main/java/edu/cmu/oli/content/contentfiles/writers/ResourceToXml.java
+++ b/src/main/java/edu/cmu/oli/content/contentfiles/writers/ResourceToXml.java
@@ -798,7 +798,7 @@ public class ResourceToXml {
                 }
             }
             if (el.getName().equalsIgnoreCase("content")) {
-                if ((el.getValue().isEmpty())) {
+                if ((el.getValue().isEmpty()) && el.getChildren().size() == 0) {
                     el.detach();
                 }
             }


### PR DESCRIPTION
This PR runs the "find dataset packages" query across parent packages so that it will find data for packages cloned from course versions that do not have student data associated with them. Basically, the issue was that when you clone a package and try to create a dataset from the clone, it only looked for data from the initial clone point, not previous versions of the cloned-from package.

From the Jira ticket:
"The dataset creator looks for previous versions of a course by id so that datasets can be created if the latest version of a course has no active student data. However, when you clone a course from a version with no active data, the dataset creator simply looks for student data from that "cloned from" version without going back to previous versions which DO have data. We need to expand the dataset creator to use previous versions of the "parent package" for cloned courses."

Risk: medium to dataset creation, low to the rest of the content-service
Stability: stable, need to test on shattrath
