### PR TITLE
fix missing images issue

### DIFF
--- a/src/main/java/edu/cmu/oli/content/contentfiles/writers/ResourceToXml.java
+++ b/src/main/java/edu/cmu/oli/content/contentfiles/writers/ResourceToXml.java
@@ -798,7 +798,7 @@ public class ResourceToXml {
                 }
             }
             if (el.getName().equalsIgnoreCase("content")) {
-                if ((el.getValue().isEmpty())) {
+                if ((el.getValue().isEmpty()) && el.getChildren().size() == 0) {
                     el.detach();
                 }
             }


### PR DESCRIPTION
Fix issue with supporting content being lost when only containing an image

Steps to recreate issue:
* Create new assessment in xml with image in supporting content
* Touch redeploy.do
* Open new assessment in editor
* At this point, once the "notify" persistence action is triggered and the assessment is saved, the xml is changed and loses the supporting content. However, the json retains the `content` tag
* The json with the `content` tag is sent to the server and the <content> tag is lost because it is incorrectly read as empty
* At re-deploy/re-import, the xml is consumed and the supporting content is lost

risk: low
stability: stable