### PR TITLE
Authoring 1872 download dataset

### DIFF
--- a/src/main/java/edu/cmu/oli/content/analytics/DatasetBuilder.java
+++ b/src/main/java/edu/cmu/oli/content/analytics/DatasetBuilder.java
@@ -397,16 +397,12 @@ public class DatasetBuilder {
     }
 
     private String toSqlString(final String x) {
-        final StringBuilder builder = new StringBuilder();
-        builder.append("'");
-        builder.append(x);
-        builder.append("'");
-        return builder.toString();
+        return "'" + x + "'";
     }
 
     private String toSqlString(final List<String> xs) {
         if (xs.size() == 1) {
-            return "'" + xs.get(0) + "'";
+            return toSqlString(xs.get(0));
         }
 
         final StringBuilder builder = new StringBuilder();
@@ -415,24 +411,6 @@ public class DatasetBuilder {
         builder.replace(builder.lastIndexOf(",") - 1, builder.lastIndexOf("'"), "");
         return builder.toString();
     }
-
-    // private <T> T findResource(T resourceType, String guid) {
-    // T object = null;
-    // try {
-    // object = em.find(resourceType, guid);
-    // if (object == null) {
-    // String message = "Error: resource requested was not found " + guid;
-    // log.error(message);
-    // throw new ResourceException(Response.Status.NOT_FOUND, guid, message);
-    // }
-    // } catch (IllegalArgumentException e) {
-    // String message = "Server Error while locating package " + guid;
-    // log.error(message);
-    // throw new ResourceException(Response.Status.INTERNAL_SERVER_ERROR, guid,
-    // message);
-    // }
-    // return object;
-    // }
 
     private Dataset findDataset(String datasetGuid) {
         Dataset dataset = null;

--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/AnalyticsResource.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/AnalyticsResource.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import javax.annotation.PostConstruct;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
@@ -51,9 +52,13 @@ public class AnalyticsResource {
     @Context
     private HttpServletRequest httpServletRequest;
 
-    @Context
-    private AppSecurityContext appSecurityContext = appSecurityContextFactory
-            .extractSecurityContext(httpServletRequest);
+    // private AppSecurityContext appSecurityContext;
+
+    // @PostConstruct
+    // public void init(){
+    // this.appSecurityContext =
+    // appSecurityContextFactory.extractSecurityContext(httpServletRequest);
+    // }
 
     @GET
     @Path("v1/analytics/{packageGuid}")
@@ -64,6 +69,7 @@ public class AnalyticsResource {
             @ApiResponse(responseCode = "404", description = "No datasets found for package guid") })
     public void getPackageDatasets(@Suspended AsyncResponse response, @PathParam("packageGuid") String packageGuid) {
         missingParameterResponse(response, packageGuid);
+        AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
 
         CompletableFuture.supplyAsync(() -> manager.getPackageDatasets(appSecurityContext, packageGuid), executor)
                 .thenApply(this::serializeResponse).exceptionally(ExceptionHandler::handleExceptions)
@@ -79,6 +85,7 @@ public class AnalyticsResource {
             @ApiResponse(responseCode = "404", description = "No dataset found with that guid") })
     public void getDataset(@Suspended AsyncResponse response, @PathParam("datasetGuid") String datasetGuid) {
         missingParameterResponse(response, datasetGuid);
+        AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
 
         CompletableFuture.supplyAsync(() -> manager.getDataset(appSecurityContext, datasetGuid), executor)
                 .thenApply(this::serializeResponse).exceptionally(ExceptionHandler::handleExceptions)
@@ -94,6 +101,7 @@ public class AnalyticsResource {
             @ApiResponse(responseCode = "404", description = "No package found with that guid") })
     public void createDataset(@Suspended AsyncResponse response, @PathParam("packageGuid") String packageGuid) {
         missingParameterResponse(response, packageGuid);
+        AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
 
         CompletableFuture.supplyAsync(() -> manager.createDataset(appSecurityContext, packageGuid), executor)
                 .thenApply(this::serializeResponse).exceptionally(ExceptionHandler::handleExceptions)
@@ -110,6 +118,7 @@ public class AnalyticsResource {
             @ApiResponse(responseCode = "404", description = "No dataset found with that guid") })
     public void exportDataset(@Suspended AsyncResponse response, @PathParam("datasetGuid") String datasetGuid) {
         missingParameterResponse(response, datasetGuid);
+        AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
 
         CompletableFuture.supplyAsync(() -> manager.exportDataset(appSecurityContext, datasetGuid), executor)
                 .thenApply((datasetBitStream) -> Response.ok(new ByteArrayInputStream(datasetBitStream.toByteArray()))

--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/AnalyticsResource.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/AnalyticsResource.java
@@ -20,11 +20,14 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import java.io.ByteArrayInputStream;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
@@ -38,9 +41,6 @@ public class AnalyticsResource {
     @Inject
     AnalyticsResourceManager manager;
 
-    @Context
-    private HttpServletRequest httpServletRequest;
-
     @Inject
     AppSecurityContextFactory appSecurityContextFactory;
 
@@ -48,20 +48,23 @@ public class AnalyticsResource {
     @Dedicated("AnalyticsResourceApiExecutor")
     ExecutorService executor;
 
+    @Context
+    private HttpServletRequest httpServletRequest;
+
+    @Context
+    private AppSecurityContext appSecurityContext = appSecurityContextFactory
+            .extractSecurityContext(httpServletRequest);
+
     @GET
     @Path("v1/analytics/{packageGuid}")
     @Operation(summary = "Fetch datasets by package GUID", responses = {
-            @ApiResponse(responseCode = "200", description = "Successful response including all of a package's datasets", content = {
+            @ApiResponse(responseCode = "200", description = "All of a package's datasets", content = {
                     @Content(mediaType = "application/json") }),
             @ApiResponse(responseCode = "400", description = "Invalid request information supplied"),
-            @ApiResponse(responseCode = "404", description = "No datasets found for package guid"),
-            @ApiResponse(responseCode = "403", description = "Request not authorized") })
+            @ApiResponse(responseCode = "404", description = "No datasets found for package guid") })
     public void getPackageDatasets(@Suspended AsyncResponse response, @PathParam("packageGuid") String packageGuid) {
-        if (packageGuid == null) {
-            response.resume(ExceptionHandler.errorResponse("Parameters missing", Response.Status.BAD_REQUEST));
-            return;
-        }
-        AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
+        missingParameterResponse(response, packageGuid);
+
         CompletableFuture.supplyAsync(() -> manager.getPackageDatasets(appSecurityContext, packageGuid), executor)
                 .thenApply(this::serializeResponse).exceptionally(ExceptionHandler::handleExceptions)
                 .thenAccept(response::resume);
@@ -70,16 +73,13 @@ public class AnalyticsResource {
     @GET
     @Path("v1/analytics/dataset/{datasetGuid}")
     @Operation(summary = "Find dataset by GUID", responses = {
-            @ApiResponse(responseCode = "200", description = "Successful response, full dataset for the given GUID", content = {
+            @ApiResponse(responseCode = "200", description = "Full dataset for the given GUID", content = {
                     @Content(mediaType = "application/json") }),
             @ApiResponse(responseCode = "400", description = "No datasetGuid supplied"),
             @ApiResponse(responseCode = "404", description = "No dataset found with that guid") })
     public void getDataset(@Suspended AsyncResponse response, @PathParam("datasetGuid") String datasetGuid) {
-        if (datasetGuid == null) {
-            response.resume(ExceptionHandler.errorResponse("Parameters missing", Response.Status.BAD_REQUEST));
-            return;
-        }
-        AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
+        missingParameterResponse(response, datasetGuid);
+
         CompletableFuture.supplyAsync(() -> manager.getDataset(appSecurityContext, datasetGuid), executor)
                 .thenApply(this::serializeResponse).exceptionally(ExceptionHandler::handleExceptions)
                 .thenAccept(response::resume);
@@ -88,19 +88,41 @@ public class AnalyticsResource {
     @POST
     @Path("v1/analytics/dataset/{packageGuid}")
     @Operation(summary = "Create dataset for a package GUID", responses = {
-            @ApiResponse(responseCode = "200", description = "Successful response, includes the GUID for the to-be-created dataset", content = {
+            @ApiResponse(responseCode = "200", description = "GUID for the to-be-created dataset", content = {
                     @Content(mediaType = "application/json", schema = @Schema(example = "{guid: 2c92808a685bb18b01685c6782a500c1, message: 'dataset status'}")) }),
             @ApiResponse(responseCode = "400", description = "No packageGuid supplied or no data available for the course package"),
             @ApiResponse(responseCode = "404", description = "No package found with that guid") })
     public void createDataset(@Suspended AsyncResponse response, @PathParam("packageGuid") String packageGuid) {
-        if (packageGuid == null) {
-            response.resume(ExceptionHandler.errorResponse("Parameters missing", Response.Status.BAD_REQUEST));
-            return;
-        }
-        AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
+        missingParameterResponse(response, packageGuid);
+
         CompletableFuture.supplyAsync(() -> manager.createDataset(appSecurityContext, packageGuid), executor)
                 .thenApply(this::serializeResponse).exceptionally(ExceptionHandler::handleExceptions)
                 .thenAccept(response::resume);
+    }
+
+    @GET
+    @Path("v1/analytics/dataset/{datasetGuid}/export")
+    @Produces("application/zip")
+    @Operation(summary = "Export dataset by dataset GUID", responses = {
+            @ApiResponse(responseCode = "200", description = "Zipped TSV dataset download with three files (byPart, bySkill, byResource) for the given GUID", content = {
+                    @Content(mediaType = "application/json") }),
+            @ApiResponse(responseCode = "400", description = "No datasetGuid supplied"),
+            @ApiResponse(responseCode = "404", description = "No dataset found with that guid") })
+    public void exportDataset(@Suspended AsyncResponse response, @PathParam("datasetGuid") String datasetGuid) {
+        missingParameterResponse(response, datasetGuid);
+
+        CompletableFuture.supplyAsync(() -> manager.exportDataset(appSecurityContext, datasetGuid), executor)
+                .thenApply((datasetBitStream) -> Response.ok(new ByteArrayInputStream(datasetBitStream.toByteArray()))
+                        .header("Content-Disposition", "attachment; filename=\"" + "dataset.zip" + "\"").build())
+                .exceptionally(ExceptionHandler::handleExceptions).thenAccept(response::resume);
+    }
+
+    // Helpers
+
+    private void missingParameterResponse(AsyncResponse response, String parameter) {
+        if (parameter == null) {
+            response.resume(ExceptionHandler.errorResponse("Parameters missing", Response.Status.BAD_REQUEST));
+        }
     }
 
     private Response serializeResponse(JsonElement response) {

--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/AnalyticsResource.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/AnalyticsResource.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import javax.annotation.PostConstruct;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
@@ -51,14 +50,6 @@ public class AnalyticsResource {
 
     @Context
     private HttpServletRequest httpServletRequest;
-
-    // private AppSecurityContext appSecurityContext;
-
-    // @PostConstruct
-    // public void init(){
-    // this.appSecurityContext =
-    // appSecurityContextFactory.extractSecurityContext(httpServletRequest);
-    // }
 
     @GET
     @Path("v1/analytics/{packageGuid}")

--- a/src/main/java/edu/cmu/oli/content/boundary/managers/AnalyticsResourceManager.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/managers/AnalyticsResourceManager.java
@@ -142,7 +142,6 @@ public class AnalyticsResourceManager {
         output.put("byResource", byResourceToTsv(json.get("byResource").getAsJsonArray()));
         output.put("byPart", byPartToTsv(json.get("byPart").getAsJsonArray()));
         output.put("bySkill", bySkillToTsv(json.get("bySkill").getAsJsonArray()));
-        System.out.println("Output size: " + output.entrySet().size());
         return output;
     }
 

--- a/src/main/java/edu/cmu/oli/content/boundary/managers/AnalyticsResourceManager.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/managers/AnalyticsResourceManager.java
@@ -18,8 +18,13 @@ import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
 import javax.ws.rs.core.Response;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
+import java.util.stream.IntStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static edu.cmu.oli.content.security.Roles.ADMIN;
 import static edu.cmu.oli.content.security.Roles.CONTENT_DEVELOPER;
@@ -49,41 +54,17 @@ public class AnalyticsResourceManager {
     AppSecurityController securityManager;
 
     public JsonElement getPackageDatasets(AppSecurityContext session, String packageGuid) {
-        securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), packageGuid, "name=" + packageGuid,
-                Arrays.asList(Scopes.VIEW_MATERIAL_ACTION));
-
-        TypedQuery<Dataset> q = em.createNamedQuery("Dataset.findByPackageGuid", Dataset.class);
-        q.setParameter("packageGuid", packageGuid);
-        List<Dataset> resultList = q.getResultList();
-
-        if (resultList.isEmpty()) {
-            final String message = "Get dataset error: can't find datasets for package guid " + packageGuid;
-            throw new ResourceException(Response.Status.NOT_FOUND, packageGuid, message);
-        }
+        authorizePackagePrivileges(session, packageGuid);
 
         Gson gson = AppUtils.gsonBuilder().excludeFieldsWithoutExposeAnnotation().serializeNulls().create();
-        return gson.toJsonTree(resultList, new TypeToken<ArrayList<ContentPackage>>() {
+        return gson.toJsonTree(findDatasets(packageGuid), new TypeToken<ArrayList<ContentPackage>>() {
         }.getType());
     }
 
     public JsonElement getDataset(AppSecurityContext session, String datasetGuid) {
-        // Verify basic authentication before executing any code
-        securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), null, null, null);
-
-        TypedQuery<Dataset> q = em.createNamedQuery("Dataset.findByGuid", Dataset.class);
-        q.setParameter("guid", datasetGuid);
-        List<Dataset> resultList = q.getResultList();
-        if (resultList.isEmpty()) {
-            final String message = "getDataset error: can't find dataset with guid " + datasetGuid;
-            throw new ResourceException(Response.Status.NOT_FOUND, datasetGuid, message);
-        }
-        Dataset dataset = q.getResultList().get(0);
-
-        ContentPackage contentPackage = dataset.getContentPackage();
-
-        // Authorize users with access to the package the dataset is tied to
-        securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), contentPackage.getGuid(),
-                "name=" + contentPackage.getGuid(), Arrays.asList(Scopes.VIEW_MATERIAL_ACTION));
+        authorizeBasicPrivileges(session);
+        Dataset dataset = findDataset(datasetGuid);
+        authorizePackagePrivileges(session, dataset.getContentPackage().getGuid());
 
         Gson gson = AppUtils.gsonBuilder().excludeFieldsWithoutExposeAnnotation().serializeNulls().create();
         JsonElement result = gson.toJsonTree(dataset, new TypeToken<Dataset>() {
@@ -98,20 +79,12 @@ public class AnalyticsResourceManager {
     }
 
     public JsonElement createDataset(AppSecurityContext session, final String packageGuid) {
-        securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), packageGuid, "name=" + packageGuid,
-                Arrays.asList(Scopes.VIEW_MATERIAL_ACTION));
-
-        JsonObject datasetInfo = new JsonObject();
+        authorizePackagePrivileges(session, packageGuid);
 
         // Return if already currently processing a dataset request for this packageGuid
-        TypedQuery<Dataset> q = em.createNamedQuery("Dataset.findProcessingByPackageGuid", Dataset.class);
-        q.setParameter("packageGuid", packageGuid);
-        List<Dataset> processingDatasets = q.getResultList();
+        List<Dataset> processingDatasets = getProcessingDatasets(packageGuid);
         if (!processingDatasets.isEmpty()) {
-            String guid = processingDatasets.get(0).getGuid();
-            datasetInfo.addProperty("guid", guid);
-            datasetInfo.addProperty("message", "Already processing dataset");
-            return datasetInfo;
+            return setDatasetInfo(processingDatasets.get(0), "Already processing dataset");
         }
 
         Dataset dataset = new Dataset();
@@ -123,9 +96,137 @@ public class AnalyticsResourceManager {
         es.submit(() -> datasetBuilder.build(dataset.getGuid()));
 
         // Immediately return the guid of the dataset being processed
+        return setDatasetInfo(dataset, "Creating new dataset");
+    }
+
+    public ByteArrayOutputStream exportDataset(AppSecurityContext session, String datasetGuid) {
+        authorizeBasicPrivileges(session);
+        Dataset dataset = findDataset(datasetGuid);
+        authorizePackagePrivileges(session, dataset.getContentPackage().getGuid());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        datasetJsonToTsv(dataset).entrySet().forEach(slice -> {
+            try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+                ZipEntry entry = new ZipEntry(slice.getKey());
+                zos.putNextEntry(entry);
+                zos.write(slice.getValue().getBytes());
+                zos.closeEntry();
+            } catch (IOException e) {
+                log.error(e.getMessage(), e);
+                throw new ResourceException(Response.Status.INTERNAL_SERVER_ERROR, datasetGuid,
+                        "Unable to export dataset");
+            }
+        });
+
+        return baos;
+    }
+
+    private JsonObject setDatasetInfo(Dataset dataset, String message) {
+        JsonObject datasetInfo = new JsonObject();
         datasetInfo.addProperty("guid", dataset.getGuid());
-        datasetInfo.addProperty("message", "Creating new dataset");
+        datasetInfo.addProperty("message", message);
         return datasetInfo;
+    }
+
+    private List<Dataset> getProcessingDatasets(String packageGuid) {
+        TypedQuery<Dataset> q = em.createNamedQuery("Dataset.findProcessingByPackageGuid", Dataset.class);
+        q.setParameter("packageGuid", packageGuid);
+        return (List<Dataset>) q.getResultList();
+    }
+
+    // Three slices - byPart, bySkill, and byResource
+    private Map<String, String> datasetJsonToTsv(Dataset dataset) {
+        Map<String, String> output = new HashMap<>();
+        JsonObject json = dataset.getDatasetBlob().getBodyJson().getAsJsonObject();
+        output.put("byResource", byResourceToTsv(json.get("byResource").getAsJsonArray()));
+        output.put("byPart", byPartToTsv(json.get("byPart").getAsJsonArray()));
+        output.put("bySkill", bySkillToTsv(json.get("bySkill").getAsJsonArray()));
+        return output;
+    }
+
+    private String byResourceToTsv(JsonArray dataRows) {
+        // Order of titles matters here!
+        List<String> titleHeaders = Arrays.asList("Resource", "Title");
+        Set<String> titleKeys = new LinkedHashSet<String>();
+        titleKeys.addAll(Arrays.asList("resource", "title"));
+
+        return datasetToTsv(titleHeaders, titleKeys, dataRows);
+    }
+
+    private String byPartToTsv(JsonArray dataRows) {
+        List<String> headers = Arrays.asList("ID", "Resource", "Title", "Question", "Revision", "Part",
+                "Submit and Compare");
+        Set<String> keys = new LinkedHashSet<String>();
+        keys.addAll(Arrays.asList("id", "resource", "title", "question", "revision", "part", "submitAndCompare"));
+
+        return datasetToTsv(headers, keys, dataRows);
+    }
+
+    private String bySkillToTsv(JsonArray dataRows) {
+        List<String> headers = Arrays.asList("Skill", "Title");
+        Set<String> keys = new LinkedHashSet<String>();
+        keys.addAll(Arrays.asList("skill", "title"));
+
+        return datasetToTsv(headers, keys, dataRows);
+    }
+
+    private String datasetToTsv(List<String> headers, Set<String> keys, JsonArray dataRows) {
+        List<String> commonHeaders = Arrays.asList("Distinct Students", "Distinct Registrations", "Opportunities",
+                "Practice", "Hints", "Errors", "Eventually Correct", "First Response Correct", "Utilization - Start",
+                "Utilization - Finish", "Average Help Needed", "Average Number of Tries", "Completion Rate",
+                "Accuracy Rate");
+        List<String> allHeaders = new ArrayList<>();
+        allHeaders.addAll(headers);
+        allHeaders.addAll(commonHeaders);
+
+        List<String> commonKeys = Arrays.asList("distinctStudents", "distinctRegistrations", "opportunities",
+                "practice", "hints", "errors", "correct", "firstResponseCorrect", "utilizationStart",
+                "utilizationFinish", "avgHelpNeeded", "avgNumberOfTries", "completionRate", "accuracyRate");
+        Set<String> allKeys = new LinkedHashSet<>();
+        allKeys.addAll(keys);
+        allKeys.addAll(commonKeys);
+
+        StringBuilder tsvDataset = new StringBuilder(titleRow(allHeaders));
+        dataRows.forEach(row -> dataRowToTsv(tsvDataset, (JsonObject) row, allKeys));
+
+        return tsvDataset.toString();
+    }
+
+    private String titleRow(List<String> titles) {
+        return IntStream.range(0, titles.size())
+                .mapToObj(i -> i == titles.size() - 1 ? titles.get(i) + "\n" : titles.get(i) + "\t").toString();
+    }
+
+    private StringBuilder dataRowToTsv(StringBuilder sb, JsonObject row, Set<String> keys) {
+        Iterator<String> iterator = keys.iterator();
+        while (iterator.hasNext()) {
+            sb.append(row.get(iterator.next())).append("\t");
+        }
+
+        return sb.append("\n");
+    }
+
+    private Dataset findDataset(String datasetGuid) {
+        TypedQuery<Dataset> q = em.createNamedQuery("Dataset.findByGuid", Dataset.class);
+        q.setParameter("guid", datasetGuid);
+        List<Dataset> resultList = q.getResultList();
+        if (resultList.isEmpty()) {
+            final String message = "exportDataset error: can't find dataset with guid " + datasetGuid;
+            throw new ResourceException(Response.Status.NOT_FOUND, datasetGuid, message);
+        }
+        return resultList.get(0);
+    }
+
+    private List<Dataset> findDatasets(String packageGuid) {
+        TypedQuery<Dataset> q = em.createNamedQuery("Dataset.findByPackageGuid", Dataset.class);
+        q.setParameter("packageGuid", packageGuid);
+        List<Dataset> resultList = q.getResultList();
+        if (resultList.isEmpty()) {
+            final String message = "Get dataset error: can't find datasets for package guid " + packageGuid;
+            throw new ResourceException(Response.Status.NOT_FOUND, packageGuid, message);
+        }
+        return resultList;
     }
 
     private ContentPackage findContentPackage(String packageGuid) {
@@ -143,5 +244,16 @@ public class AnalyticsResourceManager {
             throw new ResourceException(Response.Status.INTERNAL_SERVER_ERROR, packageGuid, message);
         }
         return contentPackage;
+    }
+
+    // Verify a user has access to the package
+    private void authorizePackagePrivileges(AppSecurityContext session, String packageGuid) {
+        securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), packageGuid, "name=" + packageGuid,
+                Arrays.asList(Scopes.VIEW_MATERIAL_ACTION));
+    }
+
+    // Verify basic authentication before executing any code
+    private void authorizeBasicPrivileges(AppSecurityContext session) {
+        securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), null, null, null);
     }
 }

--- a/src/main/resources/dataset/create-by-part.sql
+++ b/src/main/resources/dataset/create-by-part.sql
@@ -8,6 +8,7 @@ select
   resources_and_parts.part_id,
   resources_and_parts.resource_id,
   resources_and_parts.resource_title,
+  resources_and_parts.question_id,
   resources_and_parts.revision,
   resources_and_parts.submit_and_compare,
   # Student enrollment

--- a/src/main/resources/dataset/create-by-resource.sql
+++ b/src/main/resources/dataset/create-by-resource.sql
@@ -21,7 +21,7 @@ from
 
   # Resource info
   (select 
-    resource.guid as resource,
+    resource.id as resource,
     resource.title,
     count(part.id) as opportunities
   from (

--- a/src/main/resources/dataset/create-by-resource.sql
+++ b/src/main/resources/dataset/create-by-resource.sql
@@ -21,7 +21,7 @@ from
 
   # Resource info
   (select 
-    resource.id as resource,
+    resource.guid as resource,
     resource.title,
     count(part.id) as opportunities
   from (


### PR DESCRIPTION
Depends on authoring-client branch

This PR allows the full dataset of a course to be exported / downloaded. The output is a zip archive with three files: **byPart**, **byResource**, and **bySkill**, each in the form of the magic spreadsheet. 

The processing is done "live" on the backend, rather than up front when the dataset is first created and saved to the database. After weighing the different options, this felt like the best decision:
- Existing datasets will be able to be downloaded without recreating the dataset
- More importantly, this allows the export to be flexible -- we can change the output based on user feedback (eg adding more calculated fields, or removing unnecessary ones) while keeping the same underlying dataset
- It also made the implementation simpler because it didn't require database migrations

I looked into making the export a single excel file with multiple tabs, but it really would've complicated things by adding new Excel/Numbers dependencies rather than just using TSV.

While I was in the dataset code, I also made some small refactors that you'll notice in the code diff. They just reduce the LOC and simplify some parts.

Risk: low
Stability: stable