### PR TITLE
limits content import processing to only 'content' and 'organization'…

### DIFF
--- a/src/main/java/edu/cmu/oli/content/controllers/LDModelControllerImpl.java
+++ b/src/main/java/edu/cmu/oli/content/controllers/LDModelControllerImpl.java
@@ -1389,8 +1389,9 @@ public class LDModelControllerImpl implements LDModelController {
                     skillsRef.add(s);
                 }
             });
-
-            obLoad.add(new ObSkill(e, skillsRef));
+            if(!skillsRef.isEmpty()) {
+                obLoad.add(new ObSkill(e, skillsRef));
+            }
         });
 
         int maxSkills1 = 0;


### PR DESCRIPTION
This PR adds a guard to the content import process to ensure that only resource files located within OLI content "standard" folders are processed during import and not any others.




Risk: minimal
Stability: high