### PR TITLE
add in thumbnail and image urls for themes

### DIFF
--- a/conf/content-service-conf.example.json
+++ b/conf/content-service-conf.example.json
@@ -36,12 +36,16 @@
     {
       "id": "whirlwind-1.4",
       "location": "/oli/repository/presentation/whirlwind-1.4",
-      "default": true
+      "default": true,
+      "thumbnail": "assets/whirl_thumb.png",
+      "image": "assets/whirl.png"
     },
     {
       "id": "chaperone-1.0",
       "location": "/oli/repository/presentation/chaperone-1.0",
-      "default": false
+      "default": false,
+      "thumbnail": "assets/chaperone_thumb.png",
+      "image": "assets/chaperone.png"
     }
   ],
   "namespaces": {

--- a/src/test/resources/edu/cmu/oli/content/contentfiles/writers/config.json
+++ b/src/test/resources/edu/cmu/oli/content/contentfiles/writers/config.json
@@ -36,12 +36,16 @@
     {
       "id": "whirlwind-1.4",
       "location": "/oli/repository/presentation/whirlwind-1.4",
-      "default": true
+      "default": true,
+      "thumbnail": "assets/whirl_thumb.png",
+      "image": "assets/whirl.png"
     },
     {
       "id": "chaperone-1.0",
       "location": "/oli/repository/presentation/chaperone-1.0",
-      "default": false
+      "default": false,
+      "thumbnail": "assets/chaperone_thumb.png",
+      "image": "assets/chaperone.png"
     }
   ],
   "namespaces": {


### PR DESCRIPTION
This PR adds in the urls for both thumbnail and full size for themes. 

RISK: Low
STABILITY: High, tested in conjunction with authoring-dev, authoring-client PRs and it works.

This has a dependence of /oli/assets directory existing that contains the images. 