### PR TITLE
Support routing by ID

### DIFF
--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/ContentResource.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/ContentResource.java
@@ -61,24 +61,24 @@ public class ContentResource {
     AppSecurityContextFactory appSecurityContextFactory;
 
     @GET
-    @Path("v1/{packageId}/resources/{resourceId}")
-    public void fetchResource(@Suspended AsyncResponse response, @PathParam("packageId") String packageId,
+    @Path("v1/{packageIdOrGuid}/resources/{resourceId}")
+    public void fetchResource(@Suspended AsyncResponse response, @PathParam("packageIdOrGuid") String packageIdOrGuid,
             @PathParam("resourceId") String resourceId) {
-        if (packageId == null || resourceId == null) {
+        if (packageIdOrGuid == null || resourceId == null) {
             response.resume(ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST));
             return;
         }
         AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
-        CompletableFuture.supplyAsync(() -> pm.fetchResource(appSecurityContext, packageId, resourceId), mes)
+        CompletableFuture.supplyAsync(() -> pm.fetchResource(appSecurityContext, packageIdOrGuid, resourceId), mes)
                 .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
                 .thenAccept(response::resume);
     }
 
     @POST
-    @Path("v1/{packageId}/resources")
-    public void createResource(@Suspended AsyncResponse response, @PathParam("packageId") String packageId,
+    @Path("v1/{packageIdOrGuid}/resources")
+    public void createResource(@Suspended AsyncResponse response, @PathParam("packageIdOrGuid") String packageIdOrGuid,
             @QueryParam("resourceType") String resourceType, JsonObject content) {
-        if (packageId == null || resourceType == null || content == null) {
+        if (packageIdOrGuid == null || resourceType == null || content == null) {
             response.resume(ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST));
             return;
         }
@@ -86,32 +86,33 @@ public class ContentResource {
         JsonParser jsonParser = new JsonParser();
         com.google.gson.JsonObject jsonObject = jsonParser.parse(AppUtils.toString(content)).getAsJsonObject();
         CompletableFuture
-                .supplyAsync(() -> createResource(appSecurityContext, packageId, resourceType, jsonObject, 0), mes)
+                .supplyAsync(() -> createResource(appSecurityContext, packageIdOrGuid, resourceType, jsonObject, 0),
+                        mes)
                 .thenAccept(response::resume);
     }
 
     @POST
-    @Path("v1/{packageId}/resources/bulk")
-    public void fetchResourcesByFilter(@Suspended AsyncResponse response, @PathParam("packageId") String packageId,
-            @QueryParam("action") String action, JsonArray body) {
-        if (packageId == null || action == null || body == null) {
+    @Path("v1/{packageIdOrGuid}/resources/bulk")
+    public void fetchResourcesByFilter(@Suspended AsyncResponse response,
+            @PathParam("packageIdOrGuid") String packageIdOrGuid, @QueryParam("action") String action, JsonArray body) {
+        if (packageIdOrGuid == null || action == null || body == null) {
             response.resume(ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST));
             return;
         }
         AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
         JsonParser jsonParser = new JsonParser();
         CompletableFuture
-                .supplyAsync(() -> pm.fetchResourcesByFilter(appSecurityContext, packageId, action,
+                .supplyAsync(() -> pm.fetchResourcesByFilter(appSecurityContext, packageIdOrGuid, action,
                         jsonParser.parse(AppUtils.toString(body)).getAsJsonArray()), mes)
                 .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
                 .thenAccept(response::resume);
     }
 
     @PUT
-    @Path("v1/{packageId}/resources/{resourceId}")
-    public void updateResource(@Suspended AsyncResponse response, @PathParam("packageId") String packageId,
+    @Path("v1/{packageIdOrGuid}/resources/{resourceId}")
+    public void updateResource(@Suspended AsyncResponse response, @PathParam("packageIdOrGuid") String packageIdOrGuid,
             @PathParam("resourceId") String resourceId, JsonObject body) {
-        if (packageId == null || resourceId == null || body == null) {
+        if (packageIdOrGuid == null || resourceId == null || body == null) {
             response.resume(ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST));
             return;
         }
@@ -119,16 +120,16 @@ public class ContentResource {
         JsonParser jsonParser = new JsonParser();
         com.google.gson.JsonObject jsonObject = jsonParser.parse(AppUtils.toString(body)).getAsJsonObject();
         CompletableFuture
-                .supplyAsync(() -> updateResource(appSecurityContext, packageId, resourceId, jsonObject, 0), mes)
+                .supplyAsync(() -> updateResource(appSecurityContext, packageIdOrGuid, resourceId, jsonObject, 0), mes)
                 .thenAccept(response::resume);
     }
 
     @PUT
-    @Path("v1/{packageId}/resources/{resourceId}/{baseRevisionId}/{nextRevisionId}")
-    public void updateResource(@Suspended AsyncResponse response, @PathParam("packageId") String packageId,
+    @Path("v1/{packageIdOrGuid}/resources/{resourceId}/{baseRevisionId}/{nextRevisionId}")
+    public void updateResource(@Suspended AsyncResponse response, @PathParam("packageIdOrGuid") String packageIdOrGuid,
             @PathParam("resourceId") String resourceId, @PathParam("baseRevisionId") String baseRevisionId,
             @PathParam("nextRevisionId") String nextRevisionId, JsonObject body) {
-        if (packageId == null || resourceId == null || baseRevisionId == null || nextRevisionId == null
+        if (packageIdOrGuid == null || resourceId == null || baseRevisionId == null || nextRevisionId == null
                 || body == null) {
             response.resume(ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST));
             return;
@@ -136,33 +137,33 @@ public class ContentResource {
         AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
         JsonParser jsonParser = new JsonParser();
         com.google.gson.JsonObject jsonObject = jsonParser.parse(AppUtils.toString(body)).getAsJsonObject();
-        CompletableFuture.supplyAsync(() -> updateRevisionBasedResource(appSecurityContext, packageId, resourceId,
+        CompletableFuture.supplyAsync(() -> updateRevisionBasedResource(appSecurityContext, packageIdOrGuid, resourceId,
                 baseRevisionId, nextRevisionId, jsonObject, 0), mes).thenAccept(response::resume);
     }
 
     @DELETE
-    @Path("v1/{packageId}/resources/{resourceId}")
-    public void deleteResource(@Suspended AsyncResponse response, @PathParam("packageId") String packageId,
+    @Path("v1/{packageIdOrGuid}/resources/{resourceId}")
+    public void deleteResource(@Suspended AsyncResponse response, @PathParam("packageIdOrGuid") String packageIdOrGuid,
             @PathParam("resourceId") String resourceId) {
-        if (packageId == null || resourceId == null) {
+        if (packageIdOrGuid == null || resourceId == null) {
             response.resume(ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST));
             return;
         }
         AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
-        CompletableFuture.supplyAsync(() -> softDelete(appSecurityContext, packageId, resourceId, 0), mes)
+        CompletableFuture.supplyAsync(() -> softDelete(appSecurityContext, packageIdOrGuid, resourceId, 0), mes)
                 .thenAccept(response::resume);
     }
 
     @GET
-    @Path("v1/{packageId}/resources/edges/{resourceId}")
-    public void fetchResourceEdges(@Suspended AsyncResponse response, @PathParam("packageId") String packageId,
-            @PathParam("resourceId") String resourceId) {
-        if (packageId == null || resourceId == null) {
+    @Path("v1/{packageIdOrGuid}/resources/edges/{resourceId}")
+    public void fetchResourceEdges(@Suspended AsyncResponse response,
+            @PathParam("packageIdOrGuid") String packageIdOrGuid, @PathParam("resourceId") String resourceId) {
+        if (packageIdOrGuid == null || resourceId == null) {
             response.resume(ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST));
             return;
         }
         AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
-        CompletableFuture.supplyAsync(() -> pm.fetchResourceEdges(appSecurityContext, packageId, resourceId), mes)
+        CompletableFuture.supplyAsync(() -> pm.fetchResourceEdges(appSecurityContext, packageIdOrGuid, resourceId), mes)
                 .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
                 .thenAccept(response::resume);
     }
@@ -173,10 +174,10 @@ public class ContentResource {
                 .build();
     }
 
-    private Response createResource(AppSecurityContext appSecurityContext, String packageId, String resourceType,
+    private Response createResource(AppSecurityContext appSecurityContext, String packageIdOrGuid, String resourceType,
             com.google.gson.JsonObject jsonObject, int retryCounter) {
         try {
-            JsonElement resource = pm.createResource(appSecurityContext, packageId, resourceType, jsonObject);
+            JsonElement resource = pm.createResource(appSecurityContext, packageIdOrGuid, resourceType, jsonObject);
             Gson gson = AppUtils.gsonBuilder().serializeNulls().create();
             return Response.status(Response.Status.OK).entity(gson.toJson(resource)).type(MediaType.APPLICATION_JSON)
                     .build();
@@ -185,16 +186,16 @@ public class ContentResource {
                     && retryCounter < configuration.get().getTransactionRetrys()) {
                 retryCounter++;
                 log.error("LockResource acquisition exception detected on resource create; retrying transaction");
-                return createResource(appSecurityContext, packageId, resourceType, jsonObject, retryCounter);
+                return createResource(appSecurityContext, packageIdOrGuid, resourceType, jsonObject, retryCounter);
             }
             return ExceptionHandler.handleExceptions(t);
         }
     }
 
-    private Response updateResource(AppSecurityContext appSecurityContext, String packageId, String resourceId,
+    private Response updateResource(AppSecurityContext appSecurityContext, String packageIdOrGuid, String resourceId,
             com.google.gson.JsonObject jsonObject, int retryCounter) {
         try {
-            JsonElement resourceJson = pm.updateResource(appSecurityContext, packageId, resourceId, jsonObject);
+            JsonElement resourceJson = pm.updateResource(appSecurityContext, packageIdOrGuid, resourceId, jsonObject);
             Gson gson = AppUtils.gsonBuilder().serializeNulls().create();
             return Response.status(Response.Status.OK).entity(gson.toJson(resourceJson))
                     .type(MediaType.APPLICATION_JSON).build();
@@ -202,18 +203,18 @@ public class ContentResource {
             if (ExceptionHandler.checkForDBLockExceptions(t)
                     && retryCounter < configuration.get().getTransactionRetrys()) {
                 log.error("LockResource acquisition exception detected on resource update; retrying transaction");
-                return updateResource(appSecurityContext, packageId, resourceId, jsonObject, ++retryCounter);
+                return updateResource(appSecurityContext, packageIdOrGuid, resourceId, jsonObject, ++retryCounter);
             }
             return ExceptionHandler.handleExceptions(t);
         }
     }
 
-    private Response updateRevisionBasedResource(AppSecurityContext appSecurityContext, String packageId,
+    private Response updateRevisionBasedResource(AppSecurityContext appSecurityContext, String packageIdOrGuid,
             String resourceId, String baseRevisionId, String nextRevision, com.google.gson.JsonObject jsonObject,
             int retryCounter) {
         try {
-            JsonElement resourceJson = pm.updateResource(appSecurityContext, packageId, resourceId, baseRevisionId,
-                    nextRevision, jsonObject);
+            JsonElement resourceJson = pm.updateResource(appSecurityContext, packageIdOrGuid, resourceId,
+                    baseRevisionId, nextRevision, jsonObject);
             Gson gson = AppUtils.gsonBuilder().serializeNulls().create();
             return Response.status(Response.Status.OK).entity(gson.toJson(resourceJson))
                     .type(MediaType.APPLICATION_JSON).build();
@@ -221,17 +222,17 @@ public class ContentResource {
             if (ExceptionHandler.checkForDBLockExceptions(t)
                     && retryCounter < configuration.get().getTransactionRetrys()) {
                 log.error("LockResource acquisition exception detected on resource update; retrying transaction");
-                return updateRevisionBasedResource(appSecurityContext, packageId, resourceId, baseRevisionId,
+                return updateRevisionBasedResource(appSecurityContext, packageIdOrGuid, resourceId, baseRevisionId,
                         nextRevision, jsonObject, ++retryCounter);
             }
             return ExceptionHandler.handleExceptions(t);
         }
     }
 
-    private Response softDelete(AppSecurityContext appSecurityContext, String packageId, String resourceId,
+    private Response softDelete(AppSecurityContext appSecurityContext, String packageIdOrGuid, String resourceId,
             int retryCounter) {
         try {
-            JsonElement resourceJson = pm.softDelete(appSecurityContext, packageId, resourceId);
+            JsonElement resourceJson = pm.softDelete(appSecurityContext, packageIdOrGuid, resourceId);
             Gson gson = AppUtils.gsonBuilder().serializeNulls().create();
             return Response.status(Response.Status.OK).entity(gson.toJson(resourceJson))
                     .type(MediaType.APPLICATION_JSON).build();
@@ -239,7 +240,7 @@ public class ContentResource {
             if (ExceptionHandler.checkForDBLockExceptions(t)
                     && retryCounter < configuration.get().getTransactionRetrys()) {
                 log.error("LockResource acquisition exception detected on resource delete; retrying transaction");
-                return softDelete(appSecurityContext, packageId, resourceId, ++retryCounter);
+                return softDelete(appSecurityContext, packageIdOrGuid, resourceId, ++retryCounter);
             }
             return ExceptionHandler.handleExceptions(t);
         }

--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/DeveloperResource.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/DeveloperResource.java
@@ -49,15 +49,15 @@ public class DeveloperResource {
     AppSecurityContextFactory appSecurityContextFactory;
 
     @GET
-    @Path("v1/{packageId}/developers")
-    public void all(@Suspended AsyncResponse response, @PathParam("packageId") String packageId) {
-        if (packageId == null) {
+    @Path("v1/{packageIdOrGuid}/developers")
+    public void all(@Suspended AsyncResponse response, @PathParam("packageIdOrGuid") String packageIdOrGuid) {
+        if (packageIdOrGuid == null) {
             String message = "Parameters missing";
             response.resume(ExceptionHandler.errorResponse(message, Response.Status.BAD_REQUEST));
             return;
         }
         AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
-        CompletableFuture.supplyAsync(() -> pm.all(appSecurityContext, packageId), mes).thenApply(this::all)
+        CompletableFuture.supplyAsync(() -> pm.all(appSecurityContext, packageIdOrGuid), mes).thenApply(this::all)
                 .exceptionally(ExceptionHandler::handleExceptions).thenAccept(response::resume);
     }
 
@@ -68,11 +68,12 @@ public class DeveloperResource {
     }
 
     @POST
-    @Path("v1/{packageId}/developers/registration")
-    public void registration(@Suspended AsyncResponse response, @PathParam("packageId") String packageId,
-            @QueryParam("action") String action, JsonArray users) {
+    @Path("v1/{packageIdOrGuidOrGuid}/developers/registration")
+    public void registration(@Suspended AsyncResponse response,
+            @PathParam("packageIdOrGuidOrGuid") String packageIdOrGuidOrGuid, @QueryParam("action") String action,
+            JsonArray users) {
 
-        if (packageId == null || users == null || action == null) {
+        if (packageIdOrGuidOrGuid == null || users == null || action == null) {
             String message = "Parameters missing";
             response.resume(ExceptionHandler.errorResponse(message, Response.Status.BAD_REQUEST));
             return;
@@ -85,7 +86,7 @@ public class DeveloperResource {
         AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
         JsonParser jsonParser = new JsonParser();
         CompletableFuture
-                .supplyAsync(() -> pm.registration(appSecurityContext, packageId, action,
+                .supplyAsync(() -> pm.registration(appSecurityContext, packageIdOrGuidOrGuid, action,
                         jsonParser.parse(AppUtils.toString(users)).getAsJsonArray()), mes)
                 .thenApply(this::registration).exceptionally(ExceptionHandler::handleExceptions)
                 .thenAccept(response::resume);

--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/EdgeResource.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/EdgeResource.java
@@ -80,13 +80,13 @@ public class EdgeResource {
             @ApiResponse(responseCode = "404", description = "Package not found"),
             @ApiResponse(responseCode = "404", description = "Package not found") })
     @GET
-    @Path("v1/{packageId}/edges")
-    public void listEdges(@Suspended AsyncResponse response, @PathParam("packageId") String packageId,
+    @Path("v1/{packageIdOrGuid}/edges")
+    public void listEdges(@Suspended AsyncResponse response, @PathParam("packageIdOrGuid") String packageIdOrGuid,
             @QueryParam("relationship") String relationship, @QueryParam("purpose") String purpose,
             @QueryParam("sourceId") String sourceId, @QueryParam("sourceType") String sourceType,
             @QueryParam("destinationId") String destinationId, @QueryParam("destinationType") String destinationType,
             @QueryParam("referenceType") String referenceType, @QueryParam("status") String status) {
-        if (packageId == null) {
+        if (packageIdOrGuid == null) {
             response.resume(ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST));
             return;
         }
@@ -109,8 +109,8 @@ public class EdgeResource {
 
         AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
         CompletableFuture
-                .supplyAsync(() -> wcm.listEdges(appSecurityContext, packageId, relationship, purpose, finalSourceIds,
-                        sourceType, finalDestinationIds, destinationType, referenceType, status), mes)
+                .supplyAsync(() -> wcm.listEdges(appSecurityContext, packageIdOrGuid, relationship, purpose,
+                        finalSourceIds, sourceType, finalDestinationIds, destinationType, referenceType, status), mes)
                 .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
                 .thenAccept(response::resume);
     }
@@ -127,9 +127,9 @@ public class EdgeResource {
             @ApiResponse(responseCode = "404", description = "Package not found"),
             @ApiResponse(responseCode = "404", description = "Package not found") })
     @POST
-    @Path("v1/{packageId}/edges/by-ids")
+    @Path("v1/{packageIdOrGuid}/edges/by-ids")
     @Consumes("application/json")
-    public void edgesByIds(@Suspended AsyncResponse response, @PathParam("packageId") String packageId,
+    public void edgesByIds(@Suspended AsyncResponse response, @PathParam("packageIdOrGuid") String packageIdOrGuid,
             @QueryParam("relationship") String relationship, @QueryParam("purpose") String purpose,
             @QueryParam("sourceType") String sourceType, @QueryParam("destinationType") String destinationType,
             @QueryParam("referenceType") String referenceType, @QueryParam("status") String status,
@@ -137,13 +137,14 @@ public class EdgeResource {
 
         EdgesByIdsRequestBody body = AppUtils.toClassObject(payload, EdgesByIdsRequestBody.class);
 
-        if (packageId == null) {
+        if (packageIdOrGuid == null) {
             response.resume(ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST));
             return;
         }
         AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
-        CompletableFuture.supplyAsync(() -> wcm.listEdges(appSecurityContext, packageId, relationship,
-                purpose, body.sourceIds, sourceType, body.destinationIds, destinationType, referenceType, status), mes)
+        CompletableFuture
+                .supplyAsync(() -> wcm.listEdges(appSecurityContext, packageIdOrGuid, relationship, purpose,
+                        body.sourceIds, sourceType, body.destinationIds, destinationType, referenceType, status), mes)
                 .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
                 .thenAccept(response::resume);
     }

--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/LDModelResource.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/LDModelResource.java
@@ -40,118 +40,92 @@ import java.util.stream.Collectors;
 @Path("/")
 public class LDModelResource {
 
-    static final String PARAMETERS_MISSING = "Parameters missing";
+        static final String PARAMETERS_MISSING = "Parameters missing";
 
-    @Inject
-    @Logging
-    Logger log;
+        @Inject
+        @Logging
+        Logger log;
 
-    @Inject
-    LDModelResourceManager ldModelResourceManager;
+        @Inject
+        LDModelResourceManager ldModelResourceManager;
 
-    @Inject
-    @Dedicated("webcontentsApiExecutor")
-    ExecutorService mes;
+        @Inject
+        @Dedicated("webcontentsApiExecutor")
+        ExecutorService mes;
 
-    @Inject
-    @ConfigurationCache
-    Instance<Configurations> config;
+        @Inject
+        @ConfigurationCache
+        Instance<Configurations> config;
 
-    @Context
-    private HttpServletRequest httpServletRequest;
+        @Context
+        private HttpServletRequest httpServletRequest;
 
-    @Inject
-    AppSecurityContextFactory appSecurityContextFactory;
+        @Inject
+        AppSecurityContextFactory appSecurityContextFactory;
 
-    @Operation(
-            summary = "Import LD model zip file",
-            description = "Import a zip file containing LD model files as payload",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "Successful LD model import",
-                            content = {
-                                    @Content(
-                                            mediaType = MediaType.APPLICATION_JSON
-                                    )
-                            }),
+        @Operation(summary = "Import LD model zip file", description = "Import a zip file containing LD model files as payload", responses = {
+                        @ApiResponse(responseCode = "200", description = "Successful LD model import", content = {
+                                        @Content(mediaType = MediaType.APPLICATION_JSON) }),
 
-                    @ApiResponse(
-                            responseCode = "400",
-                            description = "Invalid request information supplied"),
-                    @ApiResponse(
-                            responseCode = "404",
-                            description = "Package not found"),
-                    @ApiResponse(
-                            responseCode = "403",
-                            description = "Request not authorized")
-            }
-    )
-    @POST
-    @Path("v1/{packageId}/ldmodel/import")
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
-    public Response importLDModel(@PathParam("packageId") String packageId, MultipartFormDataInput multipart) {
-        if (packageId == null) {
-            return ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST);
-        }
-        Map<String, List<InputPart>> formParts = multipart.getFormDataMap();
+                        @ApiResponse(responseCode = "400", description = "Invalid request information supplied"),
+                        @ApiResponse(responseCode = "404", description = "Package not found"),
+                        @ApiResponse(responseCode = "403", description = "Request not authorized") })
+        @POST
+        @Path("v1/{packageIdOrGuid}/ldmodel/import")
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        public Response importLDModel(@PathParam("packageIdOrGuid") String packageIdOrGuid,
+                        MultipartFormDataInput multipart) {
+                if (packageIdOrGuid == null) {
+                        return ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST);
+                }
+                Map<String, List<InputPart>> formParts = multipart.getFormDataMap();
 
-        List<InputPart> files = formParts.entrySet().stream().map(e -> e.getValue())
-                .flatMap(e -> e.stream()).collect(Collectors.toList()).stream()
-                .filter(e -> getFileName(e.getHeaders())).collect(Collectors.toList());
-        if (files.isEmpty() || files.size() != 3) {
-            return ExceptionHandler.errorResponse("Error: exactly 3 files should be included in the upload request.", Response.Status.BAD_REQUEST);
-        }
-        JsonElement webContentsJson = this.ldModelResourceManager.importLDModel(appSecurityContextFactory.extractSecurityContext(httpServletRequest), files, packageId);
-        return Response.status(Response.Status.OK).entity(AppUtils.gsonBuilder().create().toJson((webContentsJson))).type(MediaType.APPLICATION_JSON).build();
-    }
-
-    @Operation(
-            summary = "Export LD model zip file",
-            description = "Export a zip file containing LD model files payload",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "Successful LD model export",
-                            content = {
-                                    @Content(
-                                            mediaType = "application/zip"
-                                    )
-                            }),
-
-                    @ApiResponse(
-                            responseCode = "400",
-                            description = "Invalid request information supplied"),
-                    @ApiResponse(
-                            responseCode = "404",
-                            description = "LDModel or Package not found"),
-                    @ApiResponse(
-                            responseCode = "403",
-                            description = "Request not authorized")
-            }
-    )
-    @GET
-    @Path("v1/{packageId}/ldmodel/export")
-    @Produces("application/zip")
-    public Response exportLDModel(@PathParam("packageId") String packageId) {
-        if (packageId == null) {
-            return ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST);
+                List<InputPart> files = formParts.entrySet().stream().map(e -> e.getValue()).flatMap(e -> e.stream())
+                                .collect(Collectors.toList()).stream().filter(e -> getFileName(e.getHeaders()))
+                                .collect(Collectors.toList());
+                if (files.isEmpty() || files.size() != 3) {
+                        return ExceptionHandler.errorResponse(
+                                        "Error: exactly 3 files should be included in the upload request.",
+                                        Response.Status.BAD_REQUEST);
+                }
+                JsonElement webContentsJson = this.ldModelResourceManager.importLDModel(
+                                appSecurityContextFactory.extractSecurityContext(httpServletRequest), files,
+                                packageIdOrGuid);
+                return Response.status(Response.Status.OK)
+                                .entity(AppUtils.gsonBuilder().create().toJson((webContentsJson)))
+                                .type(MediaType.APPLICATION_JSON).build();
         }
 
-        ByteArrayOutputStream baos = this.ldModelResourceManager.exportLDModel(appSecurityContextFactory.extractSecurityContext(httpServletRequest), packageId);
-        return Response.ok(new ByteArrayInputStream(baos.toByteArray()))
-                .header("Content-Disposition", "attachment; filename=\"" + "learning-model.zip" + "\"")
-                .build();
-    }
+        @Operation(summary = "Export LD model zip file", description = "Export a zip file containing LD model files payload", responses = {
+                        @ApiResponse(responseCode = "200", description = "Successful LD model export", content = {
+                                        @Content(mediaType = "application/zip") }),
 
-    private boolean getFileName(MultivaluedMap<String, String> headers) {
-        String contentDisp = headers.getFirst("content-disposition");
-        String[] tokens = contentDisp.split(";");
-        for (String token : tokens) {
-            if (token.trim().startsWith("filename")) {
-                return true;
-            }
+                        @ApiResponse(responseCode = "400", description = "Invalid request information supplied"),
+                        @ApiResponse(responseCode = "404", description = "LDModel or Package not found"),
+                        @ApiResponse(responseCode = "403", description = "Request not authorized") })
+        @GET
+        @Path("v1/{packageIdOrGuid}/ldmodel/export")
+        @Produces("application/zip")
+        public Response exportLDModel(@PathParam("packageIdOrGuid") String packageIdOrGuid) {
+                if (packageIdOrGuid == null) {
+                        return ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST);
+                }
+
+                ByteArrayOutputStream baos = this.ldModelResourceManager.exportLDModel(
+                                appSecurityContextFactory.extractSecurityContext(httpServletRequest), packageIdOrGuid);
+                return Response.ok(new ByteArrayInputStream(baos.toByteArray()))
+                                .header("Content-Disposition", "attachment; filename=\"" + "learning-model.zip" + "\"")
+                                .build();
         }
-        return false;
-    }
+
+        private boolean getFileName(MultivaluedMap<String, String> headers) {
+                String contentDisp = headers.getFirst("content-disposition");
+                String[] tokens = contentDisp.split(";");
+                for (String token : tokens) {
+                        if (token.trim().startsWith("filename")) {
+                                return true;
+                        }
+                }
+                return false;
+        }
 }

--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/LockResource.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/LockResource.java
@@ -49,16 +49,16 @@ public class LockResource {
     AppSecurityContextFactory appSecurityContextFactory;
 
     @GET
-    @Path("v1/{packageId}/locks")
-    public void lock(@Suspended AsyncResponse response, @PathParam("packageId") String packageId,
+    @Path("v1/{packageIdOrGuid}/locks")
+    public void lock(@Suspended AsyncResponse response, @PathParam("packageIdOrGuid") String packageIdOrGuid,
             @QueryParam("resourceId") String resourceId, @QueryParam("action") String action) {
-        if (packageId == null || resourceId == null || action == null) {
+        if (packageIdOrGuid == null || resourceId == null || action == null) {
             String message = "Parameters missing";
             response.resume(ExceptionHandler.errorResponse(message, Response.Status.BAD_REQUEST));
             return;
         }
         AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
-        CompletableFuture.supplyAsync(() -> lm.lock(appSecurityContext, packageId, resourceId, action), mes)
+        CompletableFuture.supplyAsync(() -> lm.lock(appSecurityContext, packageIdOrGuid, resourceId, action), mes)
                 .thenApply(this::lock).exceptionally(ExceptionHandler::handleExceptions).thenAccept(response::resume);
     }
 

--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/ResourceDelivery.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/ResourceDelivery.java
@@ -37,197 +37,212 @@ import java.util.concurrent.ExecutorService;
 @Path("/")
 public class ResourceDelivery {
 
-    @Inject
-    @Logging
-    Logger log;
+        @Inject
+        @Logging
+        Logger log;
 
-    @Inject
-    private ResourceDeliveryManager pm;
+        @Inject
+        private ResourceDeliveryManager pm;
 
-    @Inject
-    @Dedicated("resourcesApiExecutor")
-    ExecutorService mes;
+        @Inject
+        @Dedicated("resourcesApiExecutor")
+        ExecutorService mes;
 
-    @Inject
-    @ConfigurationCache
-    Instance<Configurations> configuration;
+        @Inject
+        @ConfigurationCache
+        Instance<Configurations> configuration;
 
-    @Context
-    private HttpServletRequest httpServletRequest;
+        @Context
+        private HttpServletRequest httpServletRequest;
 
-    @Inject
-    AppSecurityContextFactory appSecurityContextFactory;
+        @Inject
+        AppSecurityContextFactory appSecurityContextFactory;
 
-    @GET
-    @Path("v1/{packageId}/themes/available")
-    public void availableThemes(@Suspended AsyncResponse response, @PathParam("packageId") String packageId) {
-        AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
+        @GET
+        @Path("v1/{packageIdOrGuid}/themes/available")
+        public void availableThemes(@Suspended AsyncResponse response,
+                        @PathParam("packageIdOrGuid") String packageIdOrGuid) {
+                AppSecurityContext appSecurityContext = appSecurityContextFactory
+                                .extractSecurityContext(httpServletRequest);
 
-        CompletableFuture.supplyAsync(() -> pm.availableThemes(appSecurityContext, packageId), mes)
-                .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
-                .thenAccept(response::resume);
-    }
-
-    @Operation(summary = "Update package default theme", description = "Updates course content package default theme")
-    @PUT
-    @Path("v1/packages/{packageId}/theme")
-    public void updatePackageTheme(@Suspended AsyncResponse response,
-            @Parameter(description = "GUID of package to update") @PathParam("packageId") String packageId,
-            @Parameter(description = "Updated package payload in JSON format") JsonObject themeId) {
-        if (packageId == null || themeId == null) {
-            response.resume(ExceptionHandler.errorResponse("Parameters missing", Response.Status.BAD_REQUEST));
-            return;
+                CompletableFuture.supplyAsync(() -> pm.availableThemes(appSecurityContext, packageIdOrGuid), mes)
+                                .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
+                                .thenAccept(response::resume);
         }
-        JsonParser jsonParser = new JsonParser();
-        com.google.gson.JsonObject jsonObject = jsonParser.parse(AppUtils.toString(themeId)).getAsJsonObject();
-        AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
-        CompletableFuture
-                .supplyAsync(() -> pm.updatePackageTheme(appSecurityContext, packageId,
-                        jsonObject.get("theme").getAsString()), mes)
-                .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
-                .thenAccept(response::resume);
-    }
 
-    @GET
-    @Path("v1/{packageId}/resources/preview/{resourceId}")
-    public void preview(@Suspended AsyncResponse response, @PathParam("packageId") String packageId,
-            @PathParam("resourceId") String resourceId, @QueryParam("server") String server,
-            @QueryParam("redeploy") String redeploy) {
-        if (packageId == null || resourceId == null) {
-            response.resume(ExceptionHandler.errorResponse("Parameters missing", Response.Status.BAD_REQUEST));
-            return;
+        @Operation(summary = "Update package default theme", description = "Updates course content package default theme")
+        @PUT
+        @Path("v1/packages/{packageIdOrGuid}/theme")
+        public void updatePackageTheme(@Suspended AsyncResponse response,
+                        @Parameter(description = "GUID of package to update") @PathParam("packageIdOrGuid") String packageIdOrGuid,
+                        @Parameter(description = "Updated package payload in JSON format") JsonObject themeId) {
+                if (packageIdOrGuid == null || themeId == null) {
+                        response.resume(ExceptionHandler.errorResponse("Parameters missing",
+                                        Response.Status.BAD_REQUEST));
+                        return;
+                }
+                JsonParser jsonParser = new JsonParser();
+                com.google.gson.JsonObject jsonObject = jsonParser.parse(AppUtils.toString(themeId)).getAsJsonObject();
+                AppSecurityContext appSecurityContext = appSecurityContextFactory
+                                .extractSecurityContext(httpServletRequest);
+                CompletableFuture
+                                .supplyAsync(() -> pm.updatePackageTheme(appSecurityContext, packageIdOrGuid,
+                                                jsonObject.get("theme").getAsString()), mes)
+                                .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
+                                .thenAccept(response::resume);
         }
-        AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
-        CompletableFuture
-                .supplyAsync(() -> pm.previewResource(appSecurityContext, packageId, resourceId,
-                        redeploy != null ? Boolean.parseBoolean(redeploy) : false), mes)
-                .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
-                .thenAccept(response::resume);
-    }
 
-    @GET
-    @Path("{packageId}/resources/quick_preview/{resourceId}")
-    public void quickPreview(@Suspended AsyncResponse response, @PathParam("packageId") String packageId,
-            @PathParam("resourceId") String resourceId) {
-        if (packageId == null || resourceId == null) {
-            response.resume(ExceptionHandler.errorResponse("Parameters missing", Response.Status.BAD_REQUEST));
-            return;
+        @GET
+        @Path("v1/{packageIdOrGuid}/resources/preview/{resourceId}")
+        public void preview(@Suspended AsyncResponse response, @PathParam("packageIdOrGuid") String packageIdOrGuid,
+                        @PathParam("resourceId") String resourceId, @QueryParam("server") String server,
+                        @QueryParam("redeploy") String redeploy) {
+                if (packageIdOrGuid == null || resourceId == null) {
+                        response.resume(ExceptionHandler.errorResponse("Parameters missing",
+                                        Response.Status.BAD_REQUEST));
+                        return;
+                }
+                AppSecurityContext appSecurityContext = appSecurityContextFactory
+                                .extractSecurityContext(httpServletRequest);
+                CompletableFuture
+                                .supplyAsync(() -> pm.previewResource(appSecurityContext, packageIdOrGuid, resourceId,
+                                                redeploy != null ? Boolean.parseBoolean(redeploy) : false), mes)
+                                .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
+                                .thenAccept(response::resume);
         }
-        // AppSecurityContext appSecurityContext =
-        // appSecurityContextFactory.extractSecurityContext(httpServletRequest);
-        CompletableFuture.supplyAsync(() -> pm.quickPreview(null, packageId, resourceId), mes)
-                .thenApply(this::toThinPreviewResponse).exceptionally(ExceptionHandler::handleExceptions)
-                .thenAccept(response::resume);
 
-        // NewCookie cookie = new NewCookie("session",
-        // appSecurityContext.getTokenString(), "/", null, null, -1, true);
+        @GET
+        @Path("{packageIdOrGuid}/resources/quick_preview/{resourceId}")
+        public void quickPreview(@Suspended AsyncResponse response,
+                        @PathParam("packageIdOrGuid") String packageIdOrGuid,
+                        @PathParam("resourceId") String resourceId) {
+                if (packageIdOrGuid == null || resourceId == null) {
+                        response.resume(ExceptionHandler.errorResponse("Parameters missing",
+                                        Response.Status.BAD_REQUEST));
+                        return;
+                }
+                // AppSecurityContext appSecurityContext =
+                // appSecurityContextFactory.extractSecurityContext(httpServletRequest);
+                CompletableFuture.supplyAsync(() -> pm.quickPreview(null, packageIdOrGuid, resourceId), mes)
+                                .thenApply(this::toThinPreviewResponse)
+                                .exceptionally(ExceptionHandler::handleExceptions).thenAccept(response::resume);
+
+                // NewCookie cookie = new NewCookie("session",
+                // appSecurityContext.getTokenString(), "/", null, null, -1, true);
+                //
+                // String redirectUrl = httpServletRequest.getScheme() + "://" +
+                // httpServletRequest.getServerName() + "/content-service/api/"
+                // + packageIdOrGuid + "/resources/do_quick_preview/" + resourceId;
+                //
+                // CompletableFuture.supplyAsync(() -> redirectPreview(redirectUrl, cookie),
+                // mes)
+                // .exceptionally(ExceptionHandler::handleExceptions).thenAccept(response::resume);
+        }
+
+        // private Response redirectPreview(String redirectUrl, NewCookie cookie) {
+        // try {
+        // return Response.seeOther(new
+        // URI(redirectUrl)).cookie(cookie).type(MediaType.APPLICATION_JSON).build();
+        // } catch (URISyntaxException e) {
+        // throw new RuntimeException(e);
+        // }
+        // }
         //
-        // String redirectUrl = httpServletRequest.getScheme() + "://" +
-        // httpServletRequest.getServerName() + "/content-service/api/"
-        // + packageId + "/resources/do_quick_preview/" + resourceId;
+        // @GET
+        // @Path("{packageIdOrGuid}/resources/do_quick_preview/{resourceId}")
+        // public void doQuickPreview(@Suspended AsyncResponse response,
+        // @CookieParam("session") String authToken,
+        // @PathParam("packageIdOrGuid") String packageIdOrGuid,
+        // @PathParam("resourceId") String resourceId) {
         //
-        // CompletableFuture.supplyAsync(() -> redirectPreview(redirectUrl, cookie),
-        // mes)
-        // .exceptionally(ExceptionHandler::handleExceptions).thenAccept(response::resume);
-    }
+        //
+        // String serverUrl = httpServletRequest.getScheme() + "://" +
+        // httpServletRequest.getServerName() + "/";
+        // CompletableFuture.supplyAsync(() -> pm.quickPreview(null, packageIdOrGuid,
+        // resourceId, serverUrl), mes)
+        // .thenApply(this::toThinPreviewResponse).exceptionally(ExceptionHandler::handleExceptions).thenAccept(response::resume);
+        // }
 
-    // private Response redirectPreview(String redirectUrl, NewCookie cookie) {
-    // try {
-    // return Response.seeOther(new
-    // URI(redirectUrl)).cookie(cookie).type(MediaType.APPLICATION_JSON).build();
-    // } catch (URISyntaxException e) {
-    // throw new RuntimeException(e);
-    // }
-    // }
-    //
-    // @GET
-    // @Path("{packageId}/resources/do_quick_preview/{resourceId}")
-    // public void doQuickPreview(@Suspended AsyncResponse response,
-    // @CookieParam("session") String authToken,
-    // @PathParam("packageId") String packageId,
-    // @PathParam("resourceId") String resourceId) {
-    //
-    //
-    // String serverUrl = httpServletRequest.getScheme() + "://" +
-    // httpServletRequest.getServerName() + "/";
-    // CompletableFuture.supplyAsync(() -> pm.quickPreview(null, packageId,
-    // resourceId, serverUrl), mes)
-    // .thenApply(this::toThinPreviewResponse).exceptionally(ExceptionHandler::handleExceptions).thenAccept(response::resume);
-    // }
+        @POST
+        @Path("jcourse/a2/rest/{context}/{user}/{attempt}/bulk_pages_context")
+        public void inlineAssessmentBulkPageContext(@Suspended AsyncResponse response,
+                        @CookieParam("session") String authToken, @PathParam("user") String userGuid,
+                        JsonObject pageContext) {
+                // AppSecurityContext appSecurityContext =
+                // appSecurityContextFactory.extractSecurityContext(httpServletRequest);
+                String serverUrl = httpServletRequest.getScheme() + "://" + httpServletRequest.getServerName() + "/";
+                JsonParser jsonParser = new JsonParser();
+                com.google.gson.JsonObject pageContextJson = jsonParser.parse(AppUtils.toString(pageContext))
+                                .getAsJsonObject();
+                CompletableFuture
+                                .supplyAsync(() -> pm.inlineAssessmentBulkPageContext(userGuid, pageContextJson,
+                                                serverUrl), mes)
+                                .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
+                                .thenAccept(response::resume);
+        }
 
-    @POST
-    @Path("jcourse/a2/rest/{context}/{user}/{attempt}/bulk_pages_context")
-    public void inlineAssessmentBulkPageContext(@Suspended AsyncResponse response,
-            @CookieParam("session") String authToken, @PathParam("user") String userGuid, JsonObject pageContext) {
-        // AppSecurityContext appSecurityContext =
-        // appSecurityContextFactory.extractSecurityContext(httpServletRequest);
-        String serverUrl = httpServletRequest.getScheme() + "://" + httpServletRequest.getServerName() + "/";
-        JsonParser jsonParser = new JsonParser();
-        com.google.gson.JsonObject pageContextJson = jsonParser.parse(AppUtils.toString(pageContext)).getAsJsonObject();
-        CompletableFuture
-                .supplyAsync(() -> pm.inlineAssessmentBulkPageContext(userGuid, pageContextJson, serverUrl), mes)
-                .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
-                .thenAccept(response::resume);
-    }
+        @POST
+        @Path("jcourse/a2/rest/{context}/{user}/{attempt}/next_attempt")
+        public void inlineAssessmentNextAttempt(@Suspended AsyncResponse response,
+                        @CookieParam("session") String authToken, @PathParam("context") String contextGuid,
+                        @PathParam("user") String userGuid, @PathParam("attempt") int attemptNumber,
+                        @QueryParam("mode") String requestMode, String password) {
+                // AppSecurityContext appSecurityContext =
+                // appSecurityContextFactory.extractSecurityContext(httpServletRequest);
+                String serverUrl = httpServletRequest.getScheme() + "://" + httpServletRequest.getServerName() + "/";
+                CompletableFuture
+                                .supplyAsync(() -> pm.inlineAssessmentNextPageContext(contextGuid, userGuid,
+                                                attemptNumber, 1, requestMode, true, serverUrl), mes)
+                                .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
+                                .thenAccept(response::resume);
+        }
+        // @Path("/{context}/{user}/{attempt}")
 
-    @POST
-    @Path("jcourse/a2/rest/{context}/{user}/{attempt}/next_attempt")
-    public void inlineAssessmentNextAttempt(@Suspended AsyncResponse response, @CookieParam("session") String authToken,
-            @PathParam("context") String contextGuid, @PathParam("user") String userGuid,
-            @PathParam("attempt") int attemptNumber, @QueryParam("mode") String requestMode, String password) {
-        // AppSecurityContext appSecurityContext =
-        // appSecurityContextFactory.extractSecurityContext(httpServletRequest);
-        String serverUrl = httpServletRequest.getScheme() + "://" + httpServletRequest.getServerName() + "/";
-        CompletableFuture
-                .supplyAsync(() -> pm.inlineAssessmentNextPageContext(contextGuid, userGuid, attemptNumber, 1,
-                        requestMode, true, serverUrl), mes)
-                .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
-                .thenAccept(response::resume);
-    }
-    // @Path("/{context}/{user}/{attempt}")
+        @GET
+        @Path("jcourse/a2/rest/{context}/{user}/{attempt}/pages_context/{page}")
+        public void inlineAssessmentNextPage(@Suspended AsyncResponse response,
+                        @CookieParam("session") String authToken, @PathParam("context") String contextGuid,
+                        @PathParam("user") String userGuid, @PathParam("attempt") int attemptNumber,
+                        @PathParam("page") int pageNumber, @QueryParam("mode") String requestMode,
+                        @QueryParam("start") boolean start) {
+                // AppSecurityContext appSecurityContext =
+                // appSecurityContextFactory.extractSecurityContext(httpServletRequest);
+                String serverUrl = httpServletRequest.getScheme() + "://" + httpServletRequest.getServerName() + "/";
 
-    @GET
-    @Path("jcourse/a2/rest/{context}/{user}/{attempt}/pages_context/{page}")
-    public void inlineAssessmentNextPage(@Suspended AsyncResponse response, @CookieParam("session") String authToken,
-            @PathParam("context") String contextGuid, @PathParam("user") String userGuid,
-            @PathParam("attempt") int attemptNumber, @PathParam("page") int pageNumber,
-            @QueryParam("mode") String requestMode, @QueryParam("start") boolean start) {
-        // AppSecurityContext appSecurityContext =
-        // appSecurityContextFactory.extractSecurityContext(httpServletRequest);
-        String serverUrl = httpServletRequest.getScheme() + "://" + httpServletRequest.getServerName() + "/";
+                CompletableFuture
+                                .supplyAsync(() -> pm.inlineAssessmentNextPageContext(contextGuid, userGuid,
+                                                attemptNumber, pageNumber, requestMode, start, serverUrl), mes)
+                                .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
+                                .thenAccept(response::resume);
+        }
 
-        CompletableFuture
-                .supplyAsync(() -> pm.inlineAssessmentNextPageContext(contextGuid, userGuid, attemptNumber, pageNumber,
-                        requestMode, start, serverUrl), mes)
-                .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
-                .thenAccept(response::resume);
-    }
+        @POST
+        @Path("jcourse/a2/rest/{context}/{user}/{attempt}/responses_context/{questionId}")
+        public void inlineAssessmentResponsesContext(@Suspended AsyncResponse response,
+                        @CookieParam("session") String authToken, @PathParam("context") String contextGuid,
+                        @PathParam("user") String userGuid, @PathParam("attempt") int attemptNumber,
+                        @PathParam("questionId") String questionId, @QueryParam("start") boolean start,
+                        JsonObject responses) {
+                // AppSecurityContext appSecurityContext =
+                // appSecurityContextFactory.extractSecurityContext(httpServletRequest);
+                String serverUrl = httpServletRequest.getScheme() + "://" + httpServletRequest.getServerName() + "/";
+                JsonParser jsonParser = new JsonParser();
+                com.google.gson.JsonObject responsesJson = jsonParser.parse(AppUtils.toString(responses))
+                                .getAsJsonObject();
+                CompletableFuture
+                                .supplyAsync(() -> pm.inlineAssessmentResponsesContext(contextGuid, userGuid,
+                                                attemptNumber, questionId, start, responsesJson, serverUrl), mes)
+                                .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
+                                .thenAccept(response::resume);
+        }
 
-    @POST
-    @Path("jcourse/a2/rest/{context}/{user}/{attempt}/responses_context/{questionId}")
-    public void inlineAssessmentResponsesContext(@Suspended AsyncResponse response,
-            @CookieParam("session") String authToken, @PathParam("context") String contextGuid,
-            @PathParam("user") String userGuid, @PathParam("attempt") int attemptNumber,
-            @PathParam("questionId") String questionId, @QueryParam("start") boolean start, JsonObject responses) {
-        // AppSecurityContext appSecurityContext =
-        // appSecurityContextFactory.extractSecurityContext(httpServletRequest);
-        String serverUrl = httpServletRequest.getScheme() + "://" + httpServletRequest.getServerName() + "/";
-        JsonParser jsonParser = new JsonParser();
-        com.google.gson.JsonObject responsesJson = jsonParser.parse(AppUtils.toString(responses)).getAsJsonObject();
-        CompletableFuture
-                .supplyAsync(() -> pm.inlineAssessmentResponsesContext(contextGuid, userGuid, attemptNumber, questionId,
-                        start, responsesJson, serverUrl), mes)
-                .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
-                .thenAccept(response::resume);
-    }
+        private Response toThinPreviewResponse(String content) {
+                return Response.status(Response.Status.OK).entity(content).type(MediaType.TEXT_HTML).build();
+        }
 
-    private Response toThinPreviewResponse(String content) {
-        return Response.status(Response.Status.OK).entity(content).type(MediaType.TEXT_HTML).build();
-    }
-
-    private Response toResponse(JsonElement resourceJson) {
-        Gson gson = AppUtils.gsonBuilder().serializeNulls().create();
-        return Response.status(Response.Status.OK).entity(gson.toJson(resourceJson)).type(MediaType.APPLICATION_JSON)
-                .build();
-    }
+        private Response toResponse(JsonElement resourceJson) {
+                Gson gson = AppUtils.gsonBuilder().serializeNulls().create();
+                return Response.status(Response.Status.OK).entity(gson.toJson(resourceJson))
+                                .type(MediaType.APPLICATION_JSON).build();
+        }
 }

--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/WebResource.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/WebResource.java
@@ -43,103 +43,116 @@ import java.util.concurrent.ExecutorService;
 @Path("/")
 public class WebResource {
 
-    static final String PARAMETERS_MISSING = "Parameters missing";
+        static final String PARAMETERS_MISSING = "Parameters missing";
 
-    @Inject
-    @Logging
-    Logger log;
+        @Inject
+        @Logging
+        Logger log;
 
-    @Inject
-    WebResourceManager wcm;
+        @Inject
+        WebResourceManager wcm;
 
-    @Inject
-    @Dedicated("webcontentsApiExecutor")
-    ExecutorService mes;
+        @Inject
+        @Dedicated("webcontentsApiExecutor")
+        ExecutorService mes;
 
-    @Inject
-    @ConfigurationCache
-    Instance<Configurations> config;
+        @Inject
+        @ConfigurationCache
+        Instance<Configurations> config;
 
-    @Context
-    private HttpServletRequest httpServletRequest;
+        @Context
+        private HttpServletRequest httpServletRequest;
 
-    @Inject
-    AppSecurityContextFactory appSecurityContextFactory;
+        @Inject
+        AppSecurityContextFactory appSecurityContextFactory;
 
-    @Operation(summary = "Get a list of paginated WebContent items", description = "Get a list of paginated WebContent items filtered by the request's parameter values", responses = {
-            @ApiResponse(responseCode = "200", description = "Successful response for the webcontents request", content = {
-                    @Content(mediaType = "application/json", schema = @Schema(implementation = PaginatedResponse.class)) }),
-            @ApiResponse(responseCode = "400", description = "Invalid request information supplied") })
-    @GET
-    @Path("v1/{packageId}/webcontents")
-    public void listWebcontent(@Suspended AsyncResponse response, @PathParam("packageId") String packageId,
-            @QueryParam("offset") int offset, @QueryParam("limit") @DefaultValue("10") int limit,
-            @QueryParam("order") @DefaultValue("desc") String order,
-            @QueryParam("orderBy") @DefaultValue("dateCreated") String orderBy,
-            @QueryParam("guid") @DefaultValue("") String guidFilter,
-            @QueryParam("mimeFilter") @DefaultValue("") String mimeFilter,
-            @QueryParam("pathFilter") @DefaultValue("") String pathFilter,
-            @QueryParam("searchText") @DefaultValue("") String searchText) {
-        if (packageId == null) {
-            response.resume(ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST));
-            return;
-        }
-        AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
-        CompletableFuture
-                .supplyAsync(() -> wcm.webcontents(appSecurityContext, packageId, offset, limit, order, orderBy,
-                        guidFilter, mimeFilter, pathFilter, searchText), mes)
-                .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
-                .thenAccept(response::resume);
-    }
-
-    @DELETE
-    @Path("v1/{packageId}/webcontents/{webcontentId}/delete")
-    public void deleteWebcontent(@Suspended AsyncResponse response, @PathParam("packageId") String packageId,
-            @PathParam("webcontentId") String webcontentId) {
-        if (packageId == null || webcontentId == null) {
-            response.resume(ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST));
-            return;
-        }
-        AppSecurityContext appSecurityContext = appSecurityContextFactory.extractSecurityContext(httpServletRequest);
-        CompletableFuture.supplyAsync(() -> wcm.deleteWebcontent(appSecurityContext, packageId, webcontentId), mes)
-                .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
-                .thenAccept(response::resume);
-    }
-
-    @POST
-    @Path("v1/{packageId}/webcontents/upload")
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
-    public Response uploadWebcontent(@PathParam("packageId") String packageId, MultipartFormDataInput multipart) {
-        if (packageId == null) {
-            return ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST);
-        }
-        Map<String, List<InputPart>> formParts = multipart.getFormDataMap();
-        List<InputPart> files = formParts.get("file");
-        JsonElement webContentsJson = wcm.uploadWebcontent(
-                appSecurityContextFactory.extractSecurityContext(httpServletRequest), files, packageId);
-        return Response.status(Response.Status.OK).entity(AppUtils.gsonBuilder().create().toJson((webContentsJson)))
-                .type(MediaType.APPLICATION_JSON).build();
-    }
-
-    @GET
-    @Path("v1/{packageId}/webcontents/{filePath}")
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    public Response getWebContentFile(@PathParam("packageId") String packageId,
-            @PathParam("filePath") String filePath) {
-        if (packageId == null || filePath == null) {
-            return ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST);
+        @Operation(summary = "Get a list of paginated WebContent items", description = "Get a list of paginated WebContent items filtered by the request's parameter values", responses = {
+                        @ApiResponse(responseCode = "200", description = "Successful response for the webcontents request", content = {
+                                        @Content(mediaType = "application/json", schema = @Schema(implementation = PaginatedResponse.class)) }),
+                        @ApiResponse(responseCode = "400", description = "Invalid request information supplied") })
+        @GET
+        @Path("v1/{packageIdOrGuid}/webcontents")
+        public void listWebcontent(@Suspended AsyncResponse response,
+                        @PathParam("packageIdOrGuid") String packageIdOrGuid, @QueryParam("offset") int offset,
+                        @QueryParam("limit") @DefaultValue("10") int limit,
+                        @QueryParam("order") @DefaultValue("desc") String order,
+                        @QueryParam("orderBy") @DefaultValue("dateCreated") String orderBy,
+                        @QueryParam("guid") @DefaultValue("") String guidFilter,
+                        @QueryParam("mimeFilter") @DefaultValue("") String mimeFilter,
+                        @QueryParam("pathFilter") @DefaultValue("") String pathFilter,
+                        @QueryParam("searchText") @DefaultValue("") String searchText) {
+                if (packageIdOrGuid == null) {
+                        response.resume(ExceptionHandler.errorResponse(PARAMETERS_MISSING,
+                                        Response.Status.BAD_REQUEST));
+                        return;
+                }
+                AppSecurityContext appSecurityContext = appSecurityContextFactory
+                                .extractSecurityContext(httpServletRequest);
+                CompletableFuture
+                                .supplyAsync(() -> wcm.webcontents(appSecurityContext, packageIdOrGuid, offset, limit,
+                                                order, orderBy, guidFilter, mimeFilter, pathFilter, searchText), mes)
+                                .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
+                                .thenAccept(response::resume);
         }
 
-        File webcontentFile = wcm.getWebcontentFile(
-                appSecurityContextFactory.extractSecurityContext(httpServletRequest), packageId, filePath);
-        return Response.ok(webcontentFile, MediaType.APPLICATION_OCTET_STREAM)
-                .header("Content-Disposition", "attachment; filename=\"" + webcontentFile.getName() + "\"") // optional
-                .build();
-    }
+        @DELETE
+        @Path("v1/{packageIdOrGuid}/webcontents/{webcontentId}/delete")
+        public void deleteWebcontent(@Suspended AsyncResponse response,
+                        @PathParam("packageIdOrGuid") String packageIdOrGuid,
+                        @PathParam("webcontentId") String webcontentId) {
+                if (packageIdOrGuid == null || webcontentId == null) {
+                        response.resume(ExceptionHandler.errorResponse(PARAMETERS_MISSING,
+                                        Response.Status.BAD_REQUEST));
+                        return;
+                }
+                AppSecurityContext appSecurityContext = appSecurityContextFactory
+                                .extractSecurityContext(httpServletRequest);
+                CompletableFuture
+                                .supplyAsync(() -> wcm.deleteWebcontent(appSecurityContext, packageIdOrGuid,
+                                                webcontentId), mes)
+                                .thenApply(this::toResponse).exceptionally(ExceptionHandler::handleExceptions)
+                                .thenAccept(response::resume);
+        }
 
-    private Response toResponse(JsonElement element) {
-        return Response.status(Response.Status.OK).entity(AppUtils.gsonBuilder().create().toJson(element))
-                .type(MediaType.APPLICATION_JSON).build();
-    }
+        @POST
+        @Path("v1/{packageIdOrGuid}/webcontents/upload")
+        @Consumes(MediaType.MULTIPART_FORM_DATA)
+        public Response uploadWebcontent(@PathParam("packageIdOrGuid") String packageIdOrGuid,
+                        MultipartFormDataInput multipart) {
+                if (packageIdOrGuid == null) {
+                        return ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST);
+                }
+                Map<String, List<InputPart>> formParts = multipart.getFormDataMap();
+                List<InputPart> files = formParts.get("file");
+                JsonElement webContentsJson = wcm.uploadWebcontent(
+                                appSecurityContextFactory.extractSecurityContext(httpServletRequest), files,
+                                packageIdOrGuid);
+                return Response.status(Response.Status.OK)
+                                .entity(AppUtils.gsonBuilder().create().toJson((webContentsJson)))
+                                .type(MediaType.APPLICATION_JSON).build();
+        }
+
+        @GET
+        @Path("v1/{packageIdOrGuid}/webcontents/{filePath}")
+        @Produces(MediaType.APPLICATION_OCTET_STREAM)
+        public Response getWebContentFile(@PathParam("packageIdOrGuid") String packageIdOrGuid,
+                        @PathParam("filePath") String filePath) {
+                if (packageIdOrGuid == null || filePath == null) {
+                        return ExceptionHandler.errorResponse(PARAMETERS_MISSING, Response.Status.BAD_REQUEST);
+                }
+
+                File webcontentFile = wcm.getWebcontentFile(
+                                appSecurityContextFactory.extractSecurityContext(httpServletRequest), packageIdOrGuid,
+                                filePath);
+                return Response.ok(webcontentFile, MediaType.APPLICATION_OCTET_STREAM)
+                                .header("Content-Disposition",
+                                                "attachment; filename=\"" + webcontentFile.getName() + "\"") // optional
+                                .build();
+        }
+
+        private Response toResponse(JsonElement element) {
+                return Response.status(Response.Status.OK).entity(AppUtils.gsonBuilder().create().toJson(element))
+                                .type(MediaType.APPLICATION_JSON).build();
+        }
 
 }

--- a/src/main/java/edu/cmu/oli/content/boundary/managers/AnalyticsResourceManager.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/managers/AnalyticsResourceManager.java
@@ -55,10 +55,11 @@ public class AnalyticsResourceManager {
     AppSecurityController securityManager;
 
     public JsonElement getPackageDatasets(AppSecurityContext session, String packageGuid) {
-        authorizePackagePrivileges(session, packageGuid);
+        ContentPackage contentPackage = findContentPackage(packageGuid);
+        authorizePackagePrivileges(session, contentPackage.getGuid());
 
         Gson gson = AppUtils.gsonBuilder().excludeFieldsWithoutExposeAnnotation().serializeNulls().create();
-        return gson.toJsonTree(findDatasets(packageGuid), new TypeToken<ArrayList<ContentPackage>>() {
+        return gson.toJsonTree(findDatasets(contentPackage.getGuid()), new TypeToken<ArrayList<ContentPackage>>() {
         }.getType());
     }
 
@@ -80,16 +81,16 @@ public class AnalyticsResourceManager {
     }
 
     public JsonElement createDataset(AppSecurityContext session, final String packageGuid) {
-        authorizePackagePrivileges(session, packageGuid);
+        ContentPackage contentPackage = findContentPackage(packageGuid);
+        authorizePackagePrivileges(session, contentPackage.getGuid());
 
         // Return if already currently processing a dataset request for this packageGuid
-        List<Dataset> processingDatasets = getProcessingDatasets(packageGuid);
+        List<Dataset> processingDatasets = getProcessingDatasets(contentPackage.getGuid());
         if (!processingDatasets.isEmpty()) {
             return setDatasetInfo(processingDatasets.get(0), "Already processing dataset");
         }
 
         Dataset dataset = new Dataset();
-        ContentPackage contentPackage = findContentPackage(packageGuid);
         dataset.setContentPackage(contentPackage);
         contentPackage.setActiveDataset(dataset);
         em.flush();

--- a/src/main/java/edu/cmu/oli/content/boundary/managers/ContentPackageManager.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/managers/ContentPackageManager.java
@@ -961,6 +961,7 @@ public class ContentPackageManager {
 
     // packageIdentifier is db guid or packageId-version combo
     private ContentPackage findContentPackage(String packageIdOrGuid) {
+        System.out.println("PackageIdOrGuid " + packageIdOrGuid);
         ContentPackage contentPackage = null;
         Boolean isIdAndVersion = packageIdOrGuid.contains("-");
         try {

--- a/src/main/java/edu/cmu/oli/content/boundary/managers/ContentPackageManager.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/managers/ContentPackageManager.java
@@ -961,7 +961,6 @@ public class ContentPackageManager {
 
     // packageIdentifier is db guid or packageId-version combo
     private ContentPackage findContentPackage(String packageIdOrGuid) {
-        System.out.println("PackageIdOrGuid " + packageIdOrGuid);
         ContentPackage contentPackage = null;
         Boolean isIdAndVersion = packageIdOrGuid.contains("-");
         try {

--- a/src/main/java/edu/cmu/oli/content/boundary/managers/ContentResourceManager.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/managers/ContentResourceManager.java
@@ -108,9 +108,10 @@ public class ContentResourceManager {
     @Dedicated("svnExecutor")
     ExecutorService svnExecutor;
 
-    public JsonElement fetchResource(AppSecurityContext session, String packageId, String resourceId) {
-        securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), packageId, "name=" + packageId,
-                Collections.singletonList(Scopes.VIEW_MATERIAL_ACTION));
+    public JsonElement fetchResource(AppSecurityContext session, String packageIdOrGuid, String resourceId) {
+        ContentPackage contentPackage = findContentPackage(packageIdOrGuid);
+        securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), contentPackage.getGuid(),
+                "name=" + contentPackage.getGuid(), Collections.singletonList(Scopes.VIEW_MATERIAL_ACTION));
         TypedQuery<Resource> q = em.createNamedQuery("Resource.findByGuid", Resource.class);
         q.setParameter("guid", resourceId);
         List<Resource> resultList = q.getResultList();
@@ -276,8 +277,7 @@ public class ContentResourceManager {
                             builder.setExpandEntities(false);
                             Document document = builder.build(new StringReader(layoutXml));
 
-                            JsonElement layoutElement = new Xml2Json().toJson(document.getRootElement(),
-                                    false);
+                            JsonElement layoutElement = new Xml2Json().toJson(document.getRootElement(), false);
 
                             contentItem.getAsJsonObject().get("custom").getAsJsonObject().getAsJsonObject()
                                     .add("layoutData", layoutElement);
@@ -401,13 +401,14 @@ public class ContentResourceManager {
         return false;
     }
 
-    public JsonElement createResource(AppSecurityContext session, String packageId, String resourceTypeId,
+    public JsonElement createResource(AppSecurityContext session, String packageIdOrGuid, String resourceTypeId,
             JsonElement resourceContent) {
-        securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), packageId, "name=" + packageId,
-                Collections.singletonList(Scopes.EDIT_MATERIAL_ACTION));
+        ContentPackage contentPackage = findContentPackage(packageIdOrGuid);
+        securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), contentPackage.getGuid(),
+                "name=" + contentPackage.getGuid(), Collections.singletonList(Scopes.EDIT_MATERIAL_ACTION));
 
-        Resource resource = doCreate(packageId, resourceTypeId, resourceContent, session.getPreferredUsername(),
-                session.getTokenString(), true);
+        Resource resource = doCreate(contentPackage.getGuid(), resourceTypeId, resourceContent,
+                session.getPreferredUsername(), session.getTokenString(), true);
 
         Gson gson = AppUtils.gsonBuilder().excludeFieldsWithoutExposeAnnotation().serializeNulls().create();
         JsonObject resourceJson = (JsonObject) gson.toJsonTree(resource);
@@ -419,26 +420,17 @@ public class ContentResourceManager {
         return resourceJson;
     }
 
-    public Resource doCreate(String packageId, String resourceTypeId, JsonElement resourceContent, String author,
-                             String lockId, boolean throwErrors) {
+    public Resource doCreate(String packageIdOrGuid, String resourceTypeId, JsonElement resourceContent, String author,
+            String lockId, boolean throwErrors) {
+        ContentPackage contentPackage = findContentPackage(packageIdOrGuid);
         Configurations serviceConfig = this.configuration.get();
         JsonObject resourceTypeDefinition = serviceConfig.getResourceTypeById(resourceTypeId);
         if (resourceTypeDefinition == null) {
             String message = "ContentResource type not supported  " + resourceTypeId;
             log.error(message);
-            throw new ResourceException(Response.Status.BAD_REQUEST, packageId, message);
+            throw new ResourceException(Response.Status.BAD_REQUEST, contentPackage.getGuid(), message);
         }
 
-        TypedQuery<ContentPackage> q = em.createNamedQuery("ContentPackage.findByGuid", ContentPackage.class);
-        q.setParameter("guid", packageId);
-        List<ContentPackage> resultList = q.getResultList();
-        if (resultList.isEmpty()) {
-            String message = "Content Package not found " + packageId;
-            log.error(message);
-            throw new ResourceException(Response.Status.NOT_FOUND, packageId, message);
-        }
-
-        ContentPackage contentPackage = resultList.get(0);
         boolean jsonCapable = resourceTypeDefinition.get(JSON_CAPABLE).getAsBoolean();
         Resource resource = new Resource();
         resource.setType(resourceTypeDefinition.get("id").getAsString());
@@ -466,12 +458,12 @@ public class ContentResourceManager {
         TypedQuery<Resource> query = em.createQuery(
                 "select r from Resource r where r.contentPackage.guid = :pkgGuid and r.id = :id", Resource.class);
         query.setParameter("id", resource.getId());
-        query.setParameter("pkgGuid", packageId);
+        query.setParameter("pkgGuid", contentPackage.getGuid());
         if (!query.getResultList().isEmpty()) {
             String message = "ContentResource Id already used in package " + contentPackage.getId() + " Id: "
                     + resource.getId();
             log.error(message);
-            throw new ResourceException(Response.Status.PRECONDITION_FAILED, packageId, message);
+            throw new ResourceException(Response.Status.PRECONDITION_FAILED, contentPackage.getGuid(), message);
         }
 
         // Parse update payload into final xml and json documents
@@ -483,7 +475,7 @@ public class ContentResourceManager {
                 jsonCapable ? "application/json" : "text/xml");
         resource.setFileNode(fileNode);
         resource.setContentPackage(contentPackage);
-        validateXmlContent(contentPackage.getId(), resource, contentValues.get("xmlContent"), throwErrors);
+        validateXmlContent(contentPackage.getGuid(), resource, contentValues.get("xmlContent"), throwErrors);
 
         RevisionBlob revisionBlob = jsonCapable
                 ? new RevisionBlob(new JsonWrapper(new JsonParser().parse(contentValues.get("content"))))
@@ -504,10 +496,11 @@ public class ContentResourceManager {
         return resource;
     }
 
-    public JsonElement updateResource(AppSecurityContext session, String packageId, String resourceId,
+    public JsonElement updateResource(AppSecurityContext session, String packageIdOrGuid, String resourceId,
             JsonElement resourceContent) {
-        securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), packageId, "name=" + packageId,
-                Collections.singletonList(Scopes.EDIT_MATERIAL_ACTION));
+        ContentPackage contentPackage = findContentPackage(packageIdOrGuid);
+        securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), contentPackage.getGuid(),
+                "name=" + contentPackage.getGuid(), Collections.singletonList(Scopes.EDIT_MATERIAL_ACTION));
 
         this.lockController.checkLockPermission(session, resourceId, true);
 
@@ -518,7 +511,8 @@ public class ContentResourceManager {
         }
 
         String lockId = this.lockController.getLockForResource(session, resourceId, false).getLockId();
-        doUpdate(packageId, resource, resourceContent, session.getPreferredUsername(), lockId, null, true);
+        doUpdate(contentPackage.getGuid(), resource, resourceContent, session.getPreferredUsername(), lockId, null,
+                true);
 
         Gson gson = AppUtils.gsonBuilder().excludeFieldsWithoutExposeAnnotation().serializeNulls().create();
 
@@ -534,10 +528,11 @@ public class ContentResourceManager {
         return resourceJson;
     }
 
-    public JsonElement updateResource(AppSecurityContext session, String packageId, String resourceId,
+    public JsonElement updateResource(AppSecurityContext session, String packageIdOrGuid, String resourceId,
             String baseRevision, String nextRevision, JsonElement resourceContent) {
-        securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), packageId, "name=" + packageId,
-                Collections.singletonList(Scopes.EDIT_MATERIAL_ACTION));
+        ContentPackage contentPackage = findContentPackage(packageIdOrGuid);
+        securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), contentPackage.getGuid(),
+                "name=" + contentPackage.getGuid(), Collections.singletonList(Scopes.EDIT_MATERIAL_ACTION));
 
         Resource resource = findContentResource(resourceId);
         if (resource.getResourceState() == ResourceState.DELETED) {
@@ -548,7 +543,8 @@ public class ContentResourceManager {
         System.err.println("Supplied revision: " + baseRevision);
 
         if (resource.getLastRevision().getGuid().equals(baseRevision)) {
-            doUpdate(packageId, resource, resourceContent, session.getPreferredUsername(), null, nextRevision, true);
+            doUpdate(contentPackage.getGuid(), resource, resourceContent, session.getPreferredUsername(), null,
+                    nextRevision, true);
         } else {
             String message = "Conflict detected " + resourceId;
             throw new ResourceException(Response.Status.CONFLICT, resourceId, message);
@@ -568,8 +564,9 @@ public class ContentResourceManager {
         return resourceJson;
     }
 
-    public Resource doUpdate(String packageId, Resource resource, JsonElement resourceContent, String author,
-                             String lockId, String nextRevision, boolean throwErrors) {
+    public Resource doUpdate(String packageIdOrGuid, Resource resource, JsonElement resourceContent, String author,
+            String lockId, String nextRevision, boolean throwErrors) {
+        ContentPackage contentPackage = findContentPackage(packageIdOrGuid);
         JsonObject resourceTypeDefinition = null;
         if (((JsonObject) resourceContent).has("type")) {
             String type = ((JsonObject) resourceContent).get("type").getAsString();
@@ -577,8 +574,6 @@ public class ContentResourceManager {
             resourceTypeDefinition = serviceConfig.getResourceTypeById(type);
         }
         resource.getContentPackage().getEdges();
-
-        ContentPackage contentPackage = resource.getContentPackage();
 
         String p = contentPackage.getSourceLocation() + File.separator + resource.getFileNode().getPathFrom();
         Path oldPathFromResourceFile = FileSystems.getDefault().getPath(p);
@@ -643,7 +638,8 @@ public class ContentResourceManager {
         // Parse update payload into final xml and json documents
         Map<String, String> contentValues = contentValues(resourceContent, resource, jsonCapable);
 
-        Document document = validateXmlContent(packageId, resource, contentValues.get("xmlContent"), throwErrors);
+        Document document = validateXmlContent(contentPackage.getGuid(), resource, contentValues.get("xmlContent"),
+                throwErrors);
 
         Gson gson = AppUtils.gsonBuilder().setPrettyPrinting().create();
         if (jsonCapable && document != null && !resource.getType().equalsIgnoreCase("x-oli-learning_objectives")
@@ -704,10 +700,11 @@ public class ContentResourceManager {
         return resource;
     }
 
-    public JsonElement softDelete(AppSecurityContext session, String packageId, String resourceId) {
+    public JsonElement softDelete(AppSecurityContext session, String packageIdOrGuid, String resourceId) {
+        ContentPackage contentPackage = findContentPackage(packageIdOrGuid);
         this.lockController.checkLockPermission(session, resourceId, false);
-        this.securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), packageId, "name=" + packageId,
-                Collections.singletonList(Scopes.EDIT_MATERIAL_ACTION));
+        this.securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), contentPackage.getGuid(),
+                "name=" + contentPackage.getGuid(), Collections.singletonList(Scopes.EDIT_MATERIAL_ACTION));
 
         TypedQuery<Resource> q = em.createNamedQuery("Resource.findByGuid", Resource.class);
         q.setParameter("guid", resourceId);
@@ -718,7 +715,6 @@ public class ContentResourceManager {
             throw new ResourceException(Response.Status.NOT_FOUND, resourceId, message);
         }
         Resource resource = resultList.get(0);
-        ContentPackage contentPackage = resource.getContentPackage();
         Path xmlSourceFilePath = FileSystems.getDefault()
                 .getPath(contentPackage.getSourceLocation() + File.separator + resource.getFileNode().getPathFrom());
 
@@ -765,14 +761,15 @@ public class ContentResourceManager {
         return resourceJson;
     }
 
-    public JsonElement fetchResourcesByFilter(AppSecurityContext session, String packageId, String action,
+    public JsonElement fetchResourcesByFilter(AppSecurityContext session, String packageIdOrGuid, String action,
             JsonArray items) {
+        ContentPackage contentPackage = findContentPackage(packageIdOrGuid);
         if (!action.equalsIgnoreCase("byIds") && !action.equalsIgnoreCase("byTypes")) {
             String message = "Wrong action parameter; value should be either 'byIds' or 'byTypes' " + action;
             throw new ResourceException(Response.Status.BAD_REQUEST, null, message);
         }
-        securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), packageId, "name=" + packageId,
-                Collections.singletonList(Scopes.VIEW_MATERIAL_ACTION));
+        securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), contentPackage.getGuid(),
+                "name=" + contentPackage.getGuid(), Collections.singletonList(Scopes.VIEW_MATERIAL_ACTION));
         // Query q;
         CriteriaBuilder cb = em.getCriteriaBuilder();
         CriteriaQuery<Resource> criteria = cb.createQuery(Resource.class);
@@ -788,7 +785,7 @@ public class ContentResourceManager {
             }
 
             criteria.select(resourceRoot)
-                    .where(cb.and(cb.equal(resourceRoot.get("contentPackage").get("guid"), packageId),
+                    .where(cb.and(cb.equal(resourceRoot.get("contentPackage").get("guid"), contentPackage.getGuid()),
                             resourceRoot.get("type").in(types)));
 
         } else {
@@ -801,7 +798,7 @@ public class ContentResourceManager {
                 throw new ResourceException(Response.Status.BAD_REQUEST, null, message);
             }
             criteria.select(resourceRoot)
-                    .where(cb.and(cb.equal(resourceRoot.get("contentPackage").get("guid"), packageId),
+                    .where(cb.and(cb.equal(resourceRoot.get("contentPackage").get("guid"), contentPackage.getGuid()),
                             resourceRoot.get("guid").in(guids)));
 
         }
@@ -813,9 +810,10 @@ public class ContentResourceManager {
         return resourcesArray;
     }
 
-    public JsonElement fetchResourceEdges(AppSecurityContext session, String packageId, String resourceId) {
-        this.securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), packageId, "name=" + packageId,
-                Collections.singletonList(Scopes.EDIT_MATERIAL_ACTION));
+    public JsonElement fetchResourceEdges(AppSecurityContext session, String packageIdOrGuid, String resourceId) {
+        ContentPackage contentPackage = findContentPackage(packageIdOrGuid);
+        this.securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), contentPackage.getGuid(),
+                "name=" + contentPackage.getGuid(), Collections.singletonList(Scopes.EDIT_MATERIAL_ACTION));
 
         TypedQuery<Resource> q = em.createNamedQuery("Resource.findByGuid", Resource.class);
         q.setParameter("guid", resourceId);
@@ -826,7 +824,6 @@ public class ContentResourceManager {
             throw new ResourceException(Response.Status.NOT_FOUND, resourceId, message);
         }
         Resource resource = resultList.get(0);
-        ContentPackage contentPackage = resource.getContentPackage();
 
         List<Edge> edges = edgesController.edgesForResource(contentPackage, resource, false, true);
 
@@ -842,7 +839,7 @@ public class ContentResourceManager {
             Root<Resource> resourceRoot = criteria.from(Resource.class);
 
             criteria.select(resourceRoot)
-                    .where(cb.and(cb.equal(resourceRoot.get("contentPackage").get("guid"), packageId),
+                    .where(cb.and(cb.equal(resourceRoot.get("contentPackage").get("guid"), contentPackage.getGuid()),
                             resourceRoot.get("id").in(sourceIds.keySet())));
 
             List<Resource> sources = em.createQuery(criteria).getResultList();
@@ -954,7 +951,9 @@ public class ContentResourceManager {
         return resourceContent;
     }
 
-    private Document validateXmlContent(String packageId, Resource resource, String xmlContent, boolean throwErrors) {
+    private Document validateXmlContent(String packageIdOrGuid, Resource resource, String xmlContent,
+            boolean throwErrors) {
+        ContentPackage contentPackage = findContentPackage(packageIdOrGuid);
         // Validate xmlContent
         SAXBuilder builder = AppUtils.validatingSaxBuilder();
         builder.setExpandEntities(false);
@@ -992,10 +991,11 @@ public class ContentResourceManager {
         } catch (JDOMException | RuntimeException e) {
             log.error("\n\nValidation issues file=" + resource.getFileNode().getPathFrom() + "\n" + e.getMessage()
                     + "\n" + xmlContent, e);
-            throw new ResourceException(Response.Status.BAD_REQUEST, packageId, e.getMessage());
+            throw new ResourceException(Response.Status.BAD_REQUEST, contentPackage.getGuid(), e.getMessage());
         } catch (Throwable e) {
             log.error("Validation issues file=" + resource.getFileNode().getPathFrom() + "\n" + e.getMessage(), e);
-            throw new ResourceException(Response.Status.INTERNAL_SERVER_ERROR, packageId, e.getMessage());
+            throw new ResourceException(Response.Status.INTERNAL_SERVER_ERROR, contentPackage.getGuid(),
+                    e.getMessage());
         }
     }
 
@@ -1068,7 +1068,7 @@ public class ContentResourceManager {
             resourceToXml.setConfig(configuration.get());
             try {
                 xmlContent = resourceToXml.resourceToXml(resource.getType(), content);
-            }catch (Exception e){
+            } catch (Exception e) {
                 log.error(content);
                 throw e;
             }
@@ -1097,5 +1097,37 @@ public class ContentResourceManager {
             throw new ResourceException(Response.Status.INTERNAL_SERVER_ERROR, resourceGuid, message);
         }
         return resource;
+    }
+
+    // packageIdentifier is db guid or packageId-version combo
+    private ContentPackage findContentPackage(String packageIdOrGuid) {
+        ContentPackage contentPackage = null;
+        Boolean isIdAndVersion = packageIdOrGuid.contains("-");
+        try {
+            if (isIdAndVersion) {
+                String pkgId = packageIdOrGuid.substring(0, packageIdOrGuid.lastIndexOf("-"));
+                String version = packageIdOrGuid.substring(packageIdOrGuid.lastIndexOf("-") + 1);
+                TypedQuery<ContentPackage> q = em
+                        .createNamedQuery("ContentPackage.findByIdAndVersion", ContentPackage.class)
+                        .setParameter("id", pkgId).setParameter("version", version);
+
+                contentPackage = q.getResultList().isEmpty() ? null : q.getResultList().get(0);
+            } else {
+                String packageGuid = packageIdOrGuid;
+                contentPackage = em.find(ContentPackage.class, packageGuid);
+            }
+
+            if (contentPackage == null) {
+                String message = "Error: package requested was not found " + packageIdOrGuid;
+                log.error(message);
+                throw new ResourceException(Response.Status.NOT_FOUND, packageIdOrGuid, message);
+            }
+
+        } catch (IllegalArgumentException e) {
+            String message = "Server Error while locating package " + packageIdOrGuid;
+            log.error(message);
+            throw new ResourceException(Response.Status.INTERNAL_SERVER_ERROR, packageIdOrGuid, message);
+        }
+        return contentPackage;
     }
 }

--- a/src/main/java/edu/cmu/oli/content/boundary/managers/ContentResourceManager.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/managers/ContentResourceManager.java
@@ -213,6 +213,7 @@ public class ContentResourceManager {
         }
         resourceJson.add("lock",
                 gson.toJsonTree(this.lockController.getLockForResource(session, resource.getGuid(), false)));
+        resourceJson.addProperty("packageGuid", resource.getContentPackage().getGuid());
 
         return resourceJson;
     }

--- a/src/main/java/edu/cmu/oli/content/boundary/managers/LockResourceManager.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/managers/LockResourceManager.java
@@ -8,6 +8,7 @@ import edu.cmu.oli.content.ResourceException;
 import edu.cmu.oli.content.controllers.LockController;
 import edu.cmu.oli.content.logging.Logging;
 import edu.cmu.oli.content.models.ResourceEditLock;
+import edu.cmu.oli.content.models.persistance.entities.ContentPackage;
 import edu.cmu.oli.content.security.AppSecurityContext;
 import edu.cmu.oli.content.security.AppSecurityController;
 import edu.cmu.oli.content.security.Scopes;
@@ -16,10 +17,15 @@ import org.slf4j.Logger;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
+
 import java.util.Arrays;
 
 import static edu.cmu.oli.content.security.Roles.ADMIN;
 import static edu.cmu.oli.content.security.Roles.CONTENT_DEVELOPER;
+import javax.ws.rs.core.Response;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 
 /**
@@ -29,14 +35,15 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 public class LockResourceManager {
 
     enum LockActions {
-        AQUIRE,
-        RELEASE,
-        STATUS
+        AQUIRE, RELEASE, STATUS
     }
 
     @Inject
     @Logging
     Logger log;
+
+    @PersistenceContext
+    EntityManager em;
 
     @Inject
     @Secure
@@ -45,9 +52,10 @@ public class LockResourceManager {
     @Inject
     LockController lockController;
 
-    public JsonElement lock(AppSecurityContext session, String packageId, String resourceId, String action) {
-        securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER),
-                packageId, "name=" + packageId, Arrays.asList(Scopes.VIEW_MATERIAL_ACTION));
+    public JsonElement lock(AppSecurityContext session, String packageIdOrGuid, String resourceId, String action) {
+        ContentPackage contentPackage = findContentPackage(packageIdOrGuid);
+        securityManager.authorize(session, Arrays.asList(ADMIN, CONTENT_DEVELOPER), contentPackage.getGuid(),
+                "name=" + contentPackage.getGuid(), Arrays.asList(Scopes.VIEW_MATERIAL_ACTION));
         LockActions act;
         try {
             act = LockActions.valueOf(action.toUpperCase());
@@ -56,18 +64,50 @@ public class LockResourceManager {
             throw new ResourceException(BAD_REQUEST, null, message);
         }
         switch (act) {
-            case AQUIRE:
-                ResourceEditLock resourceEditLock = lockController.aquire(session, resourceId);
-                Gson gson = AppUtils.gsonBuilder().excludeFieldsWithoutExposeAnnotation().serializeNulls().create();
-                JsonElement lockJson = gson.toJsonTree(resourceEditLock);
-                return lockJson;
-            case RELEASE:
-                return new JsonPrimitive(lockController.release(session, resourceId));
-            case STATUS:
-                return new JsonPrimitive(lockController.status(resourceId));
-            default:
-                String message = "Action not supported " + action;
-                throw new ResourceException(BAD_REQUEST, null, message);
+        case AQUIRE:
+            ResourceEditLock resourceEditLock = lockController.aquire(session, resourceId);
+            Gson gson = AppUtils.gsonBuilder().excludeFieldsWithoutExposeAnnotation().serializeNulls().create();
+            JsonElement lockJson = gson.toJsonTree(resourceEditLock);
+            return lockJson;
+        case RELEASE:
+            return new JsonPrimitive(lockController.release(session, resourceId));
+        case STATUS:
+            return new JsonPrimitive(lockController.status(resourceId));
+        default:
+            String message = "Action not supported " + action;
+            throw new ResourceException(BAD_REQUEST, null, message);
         }
+    }
+
+    // packageIdentifier is db guid or packageId-version combo
+    private ContentPackage findContentPackage(String packageIdOrGuid) {
+        ContentPackage contentPackage = null;
+        Boolean isIdAndVersion = packageIdOrGuid.contains("-");
+        try {
+            if (isIdAndVersion) {
+                String pkgId = packageIdOrGuid.substring(0, packageIdOrGuid.lastIndexOf("-"));
+                String version = packageIdOrGuid.substring(packageIdOrGuid.lastIndexOf("-") + 1);
+                TypedQuery<ContentPackage> q = em
+                        .createNamedQuery("ContentPackage.findByIdAndVersion", ContentPackage.class)
+                        .setParameter("id", pkgId).setParameter("version", version);
+
+                contentPackage = q.getResultList().isEmpty() ? null : q.getResultList().get(0);
+            } else {
+                String packageGuid = packageIdOrGuid;
+                contentPackage = em.find(ContentPackage.class, packageGuid);
+            }
+
+            if (contentPackage == null) {
+                String message = "Error: package requested was not found " + packageIdOrGuid;
+                log.error(message);
+                throw new ResourceException(Response.Status.NOT_FOUND, packageIdOrGuid, message);
+            }
+
+        } catch (IllegalArgumentException e) {
+            String message = "Server Error while locating package " + packageIdOrGuid;
+            log.error(message);
+            throw new ResourceException(Response.Status.INTERNAL_SERVER_ERROR, packageIdOrGuid, message);
+        }
+        return contentPackage;
     }
 }

--- a/src/main/java/edu/cmu/oli/content/boundary/managers/ResourceDeliveryManager.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/managers/ResourceDeliveryManager.java
@@ -92,7 +92,6 @@ public class ResourceDeliveryManager {
         }
 
         Resource resource = findContentResource(resourceId, contentPackage);
-        System.out.println("Resource - " + resource.toString());
         return deployController.deployPackage(session, resource.getGuid(), previewServer, redeploy);
     }
 

--- a/src/main/java/edu/cmu/oli/content/models/persistance/entities/Dataset.java
+++ b/src/main/java/edu/cmu/oli/content/models/persistance/entities/Dataset.java
@@ -165,7 +165,7 @@ public class Dataset implements Serializable {
     this.message = message;
   }
 
-  public Dataset cloneDataset(String packageId) {
+  public Dataset cloneDataset(String packageGuid) {
     Dataset datasetClone = new Dataset();
     datasetClone.contentPackage = this.contentPackage;
     datasetClone.body = this.body;

--- a/src/main/java/edu/cmu/oli/content/models/persistance/entities/Resource.java
+++ b/src/main/java/edu/cmu/oli/content/models/persistance/entities/Resource.java
@@ -26,23 +26,21 @@ import java.util.*;
  * @author Raphael Gachuhi
  */
 @Entity
-@Table(name = "resource", indexes = {
-        @Index(columnList = "id", name = "resource_id_idx")
-})
+@Table(name = "resource", indexes = { @Index(columnList = "id", name = "resource_id_idx") })
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
-@NamedQueries({
-        @NamedQuery(name = "Resource.findAll", query = "SELECT r FROM Resource r"),
+@NamedQueries({ @NamedQuery(name = "Resource.findAll", query = "SELECT r FROM Resource r"),
         @NamedQuery(name = "Resource.findByGuid", query = "SELECT r FROM Resource r WHERE r.guid = :guid"),
         @NamedQuery(name = "Resource.findById", query = "SELECT r FROM Resource r WHERE r.id = :id"),
+        @NamedQuery(name = "Resource.findByIdAndPackage", query = "SELECT r FROM Resource r WHERE r.id = :id AND r.contentPackage = :package"),
         @NamedQuery(name = "Resource.findByType", query = "SELECT r FROM Resource r WHERE r.type = :type"),
         @NamedQuery(name = "Resource.findByTitle", query = "SELECT r FROM Resource r WHERE r.title = :title"),
         @NamedQuery(name = "Resource.findByShortTitle", query = "SELECT r FROM Resource r WHERE r.shortTitle = :shortTitle"),
         @NamedQuery(name = "Resource.findByDateCreated", query = "SELECT r FROM Resource r WHERE r.dateCreated = :dateCreated"),
         @NamedQuery(name = "Resource.findByDateUpdated", query = "SELECT r FROM Resource r WHERE r.dateUpdated = :dateUpdated"),
         @NamedQuery(name = "Resource.findByLastRevision", query = "SELECT r FROM Resource r WHERE r.lastRevision = :lastRevision"),
-        @NamedQuery(name = "Resource.findByLastSession", query = "SELECT r FROM Resource r WHERE r.lastSession = :lastSession")})
-//@Audited
+        @NamedQuery(name = "Resource.findByLastSession", query = "SELECT r FROM Resource r WHERE r.lastSession = :lastSession") })
+// @Audited
 public class Resource implements Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -110,12 +108,12 @@ public class Resource implements Serializable {
     @Column(name = "resource_state")
     private ResourceState resourceState = ResourceState.ACTIVE;
 
-    //@NotAudited
+    // @NotAudited
     @JoinColumn(name = "content_package_guid", referencedColumnName = "guid")
     @ManyToOne(fetch = FetchType.LAZY)
     private ContentPackage contentPackage;
 
-    //@NotAudited
+    // @NotAudited
     @Expose()
     @JoinColumn(name = "file_guid", referencedColumnName = "guid")
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
@@ -125,7 +123,7 @@ public class Resource implements Serializable {
     @Column(name = "build_status")
     private BuildStatus buildStatus = BuildStatus.PROCESSING;
 
-    //@Expose()
+    // @Expose()
     @Column(name = "errors", columnDefinition = "json")
     @Type(type = "json")
     private JsonWrapper errors;
@@ -249,7 +247,6 @@ public class Resource implements Serializable {
         this.fileNode = fileNode;
     }
 
-
     public BuildStatus getBuildStatus() {
         return buildStatus;
     }
@@ -257,7 +254,6 @@ public class Resource implements Serializable {
     public void setBuildStatus(BuildStatus buildStatus) {
         this.buildStatus = buildStatus;
     }
-
 
     public JsonWrapper getErrors() {
         return errors;
@@ -290,7 +286,8 @@ public class Resource implements Serializable {
         versionClone.title = this.title;
         versionClone.shortTitle = this.shortTitle;
         if (this.type.equals("x-oli-organization")) {
-            JsonObject metadata = this.metadata == null ? new JsonObject() : this.metadata.getJsonObject().getAsJsonObject();
+            JsonObject metadata = this.metadata == null ? new JsonObject()
+                    : this.metadata.getJsonObject().getAsJsonObject();
             metadata.addProperty("version", "1.0");
             versionClone.metadata = new JsonWrapper(metadata);
         } else {
@@ -302,8 +299,8 @@ public class Resource implements Serializable {
         versionClone.errors = this.errors;
 
         if (this.lastRevision == null) {
-            throw new RuntimeException("Package does not yet support revisions: packageid=" + contentPackage.getId() +
-                    " version=" + contentPackage.getVersion());
+            throw new RuntimeException("Package does not yet support revisions: packageid=" + contentPackage.getId()
+                    + " version=" + contentPackage.getVersion());
         }
 
         versionClone.transientRev = this.lastRevision.getGuid();
@@ -336,10 +333,6 @@ public class Resource implements Serializable {
 
     @Override
     public String toString() {
-        return "Resource{" +
-                "guid='" + guid + '\'' +
-                ", id='" + id + '\'' +
-                ", type='" + type + '\'' +
-                '}';
+        return "Resource{" + "guid='" + guid + '\'' + ", id='" + id + '\'' + ", type='" + type + '\'' + '}';
     }
 }

--- a/src/main/java/edu/cmu/oli/content/security/AppSecurityController.java
+++ b/src/main/java/edu/cmu/oli/content/security/AppSecurityController.java
@@ -9,22 +9,22 @@ import java.util.Set;
  */
 public interface AppSecurityController {
 
-    Set<String> authorize(AppSecurityContext session, List<Roles> roles, String packageId, String filter,
-                          List<Scopes> scopes);
+    Set<String> authorize(AppSecurityContext session, List<Roles> roles, String packageGuid, String filter,
+            List<Scopes> scopes);
 
     void updateUserAttributes(String userId, Map<String, List<String>> addAttributes, Set<String> removeAttributes);
 
     List<UserInfo> getAllUsers();
 
     Set<UserInfo> updateUsersAttributes(Set<String> userIds, Map<String, List<String>> addAttributes,
-                                        Set<String> removeAttributes);
+            Set<String> removeAttributes);
 
     void updateAllUsersAttributes(Map<String, List<String>> addAttributes, Set<String> removeAttributes);
 
     void clearAllUsersAttributes(String searchString);
 
     void createUser(String userName, String firstName, String lastName, String email, String password,
-                    Set<Roles> realmRoles);
+            Set<Roles> realmRoles);
 
     void addUserRoles(String userName, Set<Roles> realmRoles);
 

--- a/src/main/java/edu/cmu/oli/content/security/ContentPackageLockLookup.java
+++ b/src/main/java/edu/cmu/oli/content/security/ContentPackageLockLookup.java
@@ -48,10 +48,10 @@ public class ContentPackageLockLookup {
     @PersistenceContext
     EntityManager em;
 
-    public boolean lockLookup(String packageId) {
+    public boolean lockLookup(String packageGuid) {
         log.info("lockLookup");
         TypedQuery<ContentPackage> q = em.createNamedQuery("ContentPackage.findByGuid", ContentPackage.class);
-        q.setParameter("guid", packageId);
+        q.setParameter("guid", packageGuid);
 
         List<ContentPackage> resultList = q.getResultList();
         return resultList.isEmpty() ? false : !resultList.get(0).getEditable();


### PR DESCRIPTION
This looks like more changes than it is.

Basically, all I did was change any endpoint that receives a package guid to also be able to receive a packageId-version combo. If it's a packageId-version, it looks up the package and supplies the guid to any dependent methods.

I also changed some endpoints to be able to also accept a resource ID instead of a resource guid. If the server can't find a resource with the given guid, it looks up the resource in the given package by id.

Risk: medium
Stability: stable