### PR TITLE
account for duplicate keys

### DIFF
--- a/src/main/java/edu/cmu/oli/content/boundary/managers/ContentResourceManager.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/managers/ContentResourceManager.java
@@ -797,10 +797,16 @@ public class ContentResourceManager {
 
         if (!edges.isEmpty()) {
 
-            Map<String, Edge> sourceIds = edges.stream().collect(Collectors.toMap(e -> {
-                String[] split = e.getSourceId().split(":");
-                return split[2];
-            }, Function.identity()));
+            // Create a map of the source id of the edge to the edge, but
+            // careful to handle duplicate keys. This can exist if, for instance,
+            // an org includes the same workbookpage twice.
+            Map<String, Edge> sourceIds = new HashMap<>();
+            for (Edge e : edges) {
+                final String id = e.getSourceId().split(":")[2];
+                if (!sourceIds.containsKey(id)) {
+                    sourceIds.put(id, e);
+                }
+            }
 
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Resource> criteria = cb.createQuery(Resource.class);


### PR DESCRIPTION
This PR allows the deletion of resources that appear more than once in another resource. Example cases of this: an org that includes the same workbook age twice.  A workbook page that contains multiple xrefs to another workbook page, an assessment that contains two selects - each to the same external question pool.

The issue was the Collectors API in Java triggers an exception if it encounters duplicate keys when converting to a map.  I rewrote this in a more robust manner.

RISK: Low, isolated to just the fetchResourcesEdge routine.  
STABILITY: High, with this in place the delete function and warning about existing uses works correctly 