### PR TITLE
edge tracking activitys_report, fixed svn sync issue, prevent cloning…

### DIFF
--- a/src/main/java/edu/cmu/oli/content/controllers/SVNSyncController.java
+++ b/src/main/java/edu/cmu/oli/content/controllers/SVNSyncController.java
@@ -571,6 +571,9 @@ public class SVNSyncController {
     }
 
     private void createResource(String packageId, Path resourceFile, JsonObject resourceTypeDefinition) {
+        if(Files.isDirectory(resourceFile)){
+            return;
+        }
         TypedQuery<ContentPackage> q = em.createNamedQuery("ContentPackage.findByGuid", ContentPackage.class);
         q.setParameter("guid", packageId);
         List<ContentPackage> resultList = q.getResultList();

--- a/src/main/java/edu/cmu/oli/content/models/persistance/entities/ContentPackage.java
+++ b/src/main/java/edu/cmu/oli/content/models/persistance/entities/ContentPackage.java
@@ -595,9 +595,11 @@ public class ContentPackage implements Serializable {
         versionClone.buildStatus = BuildStatus.PROCESSING;
 
         this.resources.forEach(resource -> {
-            Resource resourceClone = resource.cloneVersion(volumeLocation);
-            resourceClone.setContentPackage(versionClone);
-            versionClone.addResource(resourceClone);
+            if(resource.getResourceState() != ResourceState.DELETED) {
+                Resource resourceClone = resource.cloneVersion(volumeLocation);
+                resourceClone.setContentPackage(versionClone);
+                versionClone.addResource(resourceClone);
+            }
         });
 
         versionClone.objectivesIndex = this.objectivesIndex;

--- a/src/main/java/edu/cmu/oli/workbookpage/validators/WorkbookPageValidator.java
+++ b/src/main/java/edu/cmu/oli/workbookpage/validators/WorkbookPageValidator.java
@@ -347,7 +347,7 @@ public class WorkbookPageValidator implements ResourceValidator {
     private void createInlineEdges() {
 
         // Locate all inline content in document
-        XPathExpression<Element> xexpression = xFactory.compile("//wb:inline", Filters.element(), null, workbookNamespaces.values());
+        XPathExpression<Element> xexpression = xFactory.compile("//wb:inline | //activity_report", Filters.element(), null, workbookNamespaces.values());
         List<Element> kids = xexpression.evaluate(doc);
 
         ContentPackage pkg = rsrc.getContentPackage();


### PR DESCRIPTION
This PR adds support for tracking new workbook embedded activity reports. It also addresses two minor issues.
Svn sync now properly distinguishes folders instead of trying to process these as if they were activity resources. 
Cloning or up-versioning failed due to inclusion of resources marked as "Deleted", this PR fixes that.


Risk: low
Stability: high