### PR TITLE
0.37.0 - Fix some improvement analytics errors

### DIFF
--- a/src/main/java/edu/cmu/oli/content/analytics/DatasetBuilder.java
+++ b/src/main/java/edu/cmu/oli/content/analytics/DatasetBuilder.java
@@ -70,6 +70,7 @@ public class DatasetBuilder {
     DbConnector db;
 
     private static Integer MAXIMUM_STUDENTS = 5000;
+    private static Integer MINIMUM_STUDENTS = 100;
     private static String SQL_QUERIES_FILE = "dataset/sql_queries.json";
 
     // Sql scripts read in from local files
@@ -130,6 +131,7 @@ public class DatasetBuilder {
             log.info("Dataset creation completed");
 
             dataset.setDatasetStatus(DatasetStatus.DONE);
+            dataset.setMessage("");
             dataset.setDateCompleted(new Date());
             dataset.setDatasetBlob(new DatasetBlob(new JsonWrapper(blob)));
         } catch (Throwable t) {
@@ -218,7 +220,7 @@ public class DatasetBuilder {
                 sectionGuids.add(obj.get("section_guid").getAsString());
 
                 userCount += obj.get("students").getAsInt();
-                if (userCount >= MAXIMUM_STUDENTS) {
+                if (userCount >= MAXIMUM_STUDENTS || sectionGuids.size() >= 20 && userCount >= MINIMUM_STUDENTS) {
                     break outside;
                 }
             }

--- a/src/main/java/edu/cmu/oli/content/analytics/DatasetBuilder.java
+++ b/src/main/java/edu/cmu/oli/content/analytics/DatasetBuilder.java
@@ -220,7 +220,11 @@ public class DatasetBuilder {
                 sectionGuids.add(obj.get("section_guid").getAsString());
 
                 userCount += obj.get("students").getAsInt();
-                if (userCount >= MAXIMUM_STUDENTS || sectionGuids.size() >= 20 && userCount >= MINIMUM_STUDENTS) {
+
+                Boolean hasTooManyStudents = userCount >= MAXIMUM_STUDENTS;
+                Boolean hasEnoughSectionsAndStudents = sectionGuids.size() >= 10 && userCount >= MINIMUM_STUDENTS;
+                Boolean hasTooManySections = sectionGuids.size() > 20;
+                if (hasEnoughSectionsAndStudents || hasTooManyStudents || hasTooManySections) {
                     break outside;
                 }
             }

--- a/src/main/java/edu/cmu/oli/content/analytics/DatasetBuilder.java
+++ b/src/main/java/edu/cmu/oli/content/analytics/DatasetBuilder.java
@@ -223,7 +223,7 @@ public class DatasetBuilder {
 
                 Boolean hasTooManyStudents = userCount >= MAXIMUM_STUDENTS;
                 Boolean hasEnoughSectionsAndStudents = sectionGuids.size() >= 10 && userCount >= MINIMUM_STUDENTS;
-                Boolean hasTooManySections = sectionGuids.size() > 20;
+                Boolean hasTooManySections = sectionGuids.size() > 15;
                 if (hasEnoughSectionsAndStudents || hasTooManyStudents || hasTooManySections) {
                     break outside;
                 }

--- a/src/main/java/edu/cmu/oli/content/models/persistance/entities/Dataset.java
+++ b/src/main/java/edu/cmu/oli/content/models/persistance/entities/Dataset.java
@@ -55,7 +55,7 @@ import java.util.UUID;
     @NamedQuery(name = "Dataset.findByDateCompleted", query = "SELECT r FROM Dataset r WHERE r.dateCompleted = :dateCompleted"),
     @NamedQuery(name = "Dataset.findProcessing", query = "SELECT r FROM Dataset r WHERE r.dateCompleted is null"),
     @NamedQuery(name = "Dataset.findCompleted", query = "SELECT r FROM Dataset r WHERE r.dateCompleted is not null"),
-    @NamedQuery(name = "Dataset.findProcessingByPackageGuid", query = "SELECT r FROM Dataset r WHERE r.dateCompleted is null AND r.contentPackage.guid = :packageGuid"),
+    @NamedQuery(name = "Dataset.findProcessingByPackageGuid", query = "SELECT r FROM Dataset r WHERE r.datasetStatus = edu.cmu.oli.content.models.persistance.entities.DatasetStatus.PROCESSING AND r.contentPackage.guid = :packageGuid"),
     @NamedQuery(name = "Dataset.findCompletedByPackageGuid", query = "SELECT r FROM Dataset r WHERE r.dateCompleted is not null AND r.contentPackage.guid = :packageGuid"),
     @NamedQuery(name = "Dataset.resetProcessing", query = "UPDATE Dataset SET datasetStatus = edu.cmu.oli.content.models.persistance.entities.DatasetStatus.FAILED WHERE datasetStatus = edu.cmu.oli.content.models.persistance.entities.DatasetStatus.PROCESSING") })
 public class Dataset implements Serializable {


### PR DESCRIPTION
**Problem**:
There are several problems that can come up when creating analytics datasets:
1. Some error paths fail silently
2. A failed dataset can get stuck and unable to be re-created
3. Courses with many course sections but low enrollments per section (e.g. `concepts_of_statistics` with ~150 course sections) can exceed the dataset creation query timeout.

**Solution**:
1. Wrap another section of server code with a try/catch to handle errors
2. The client and the server identified "processing" sections in different ways. We added a dataset "status" field later on, which the client was using correctly, but the server code which was written earlier didn't use this field and incorrectly identified some failed datasets as still in process, so they couldn't be restarted.
3. Expand the dataset creation pre-processing to limit the number of course sections processed. Previously, there was a maximum of 5000 students per query, but this can result in hundreds of low-enrollment sections which causes a long query time. Now the limits are < 5000 students, < 15 sections of 10 or more students each, or a combination of > 10 sections and > 100 students.

**Wireframe/Screenshot**:
None.

**Risk**:
Low.

**Areas of concern**:
Kim pointed out that the datasets for `Introduction to Statistics` v 5.0 and 5.1 have a lot of objectives that show no analytics data. I haven't been able to figure out why so many are showing up with no data even after a dataset has been created.