### PR TITLE
fix language persistence

### DIFF
--- a/data/changelog/db.changelog-0.37.0.xml
+++ b/data/changelog/db.changelog-0.37.0.xml
@@ -1,0 +1,19 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <!-- Package field for misc options (as json) -->
+    <changeSet author="zacharybluedorn@cmu.edu" id="0.37.0-1">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists columnName="misc" tableName="content_package" />
+            </not>
+        </preConditions>
+        <addColumn tableName="content_package">
+            <column name="misc" type="JSON"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/data/changelog/db.changelog-master.xml
+++ b/data/changelog/db.changelog-master.xml
@@ -13,5 +13,6 @@
     <include file="/oli/changelog/db.changelog-0.17.0.xml"/>
     <include file="/oli/changelog/db.changelog-0.25.0.xml"/>
     <include file="/oli/changelog/db.changelog-0.27.0.xml"/>
+    <include file="/oli/changelog/db.changelog-0.37.0.xml"/>
 
 </databaseChangeLog>

--- a/src/main/java/edu/cmu/oli/content/models/persistance/entities/ContentPackage.java
+++ b/src/main/java/edu/cmu/oli/content/models/persistance/entities/ContentPackage.java
@@ -241,6 +241,12 @@ public class ContentPackage implements Serializable {
     @OneToMany(mappedBy = "contentPackage", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<Edge> edges = new HashSet<>();
 
+    @Schema(hidden = true)
+    @Expose()
+    @Column(name = "misc", columnDefinition = "json")
+    @Type(type = "json")
+    private JsonWrapper misc;
+
     public ContentPackage() {
         this.init();
     }
@@ -539,6 +545,14 @@ public class ContentPackage implements Serializable {
         this.edges.remove(edge);
     }
 
+    public JsonWrapper getMisc() {
+        return misc;
+    }
+
+    public void setMisc(JsonWrapper misc) {
+        this.misc = misc;
+    }
+
     public ContentPackage shallowClone() {
         ContentPackage shallowClone = new ContentPackage();
         shallowClone.id = this.id;
@@ -563,6 +577,7 @@ public class ContentPackage implements Serializable {
         shallowClone.packageFamily = this.packageFamily;
         shallowClone.deploymentStatus = this.deploymentStatus;
         shallowClone.activeDataset = this.activeDataset;
+        shallowClone.misc = this.misc;
         return shallowClone;
     }
 
@@ -593,9 +608,10 @@ public class ContentPackage implements Serializable {
         versionClone.fileNode = this.fileNode != null ? this.fileNode.cloneVersion(volumeLocation) : null;
         versionClone.icon = this.icon != null ? this.icon.cloneVersion(webContentVolume) : null;
         versionClone.buildStatus = BuildStatus.PROCESSING;
+        versionClone.misc = this.misc;
 
         this.resources.forEach(resource -> {
-            if(resource.getResourceState() != ResourceState.DELETED) {
+            if (resource.getResourceState() != ResourceState.DELETED) {
                 Resource resourceClone = resource.cloneVersion(volumeLocation);
                 resourceClone.setContentPackage(versionClone);
                 versionClone.addResource(resourceClone);

--- a/src/main/java/edu/cmu/oli/content/models/persistance/entities/ContentPackage.java
+++ b/src/main/java/edu/cmu/oli/content/models/persistance/entities/ContentPackage.java
@@ -245,7 +245,7 @@ public class ContentPackage implements Serializable {
     @Expose()
     @Column(name = "misc", columnDefinition = "json")
     @Type(type = "json")
-    private JsonWrapper misc;
+    private JsonWrapper misc = new JsonWrapper(new JsonObject());
 
     public ContentPackage() {
         this.init();

--- a/src/main/java/edu/cmu/oli/content/resource/builders/ContentPkgJsonReader.java
+++ b/src/main/java/edu/cmu/oli/content/resource/builders/ContentPkgJsonReader.java
@@ -78,14 +78,6 @@ public final class ContentPkgJsonReader {
         JsonElement preferences = pkgJson.get("preferences");
         mnfst.setOptions(new JsonWrapper(preferences));
 
-        // JsonWrapper misc = mnfst.getMisc();
-        // JsonObject miscInfo = new JsonObject();
-        // if (misc != null) {
-        // miscInfo = misc.getJsonObject().getAsJsonObject();
-        // }
-        // miscInfo.addProperty("language", "en-US");
-        // mnfst.setMisc(new JsonWrapper(miscInfo));
-
         JsonObject defaultMisc = new JsonObject();
         defaultMisc.addProperty("language", "en_US");
         JsonElement misc = pkgJson.get("misc").getAsJsonObject();

--- a/src/main/java/edu/cmu/oli/content/resource/builders/ContentPkgJsonReader.java
+++ b/src/main/java/edu/cmu/oli/content/resource/builders/ContentPkgJsonReader.java
@@ -80,7 +80,7 @@ public final class ContentPkgJsonReader {
 
         JsonObject defaultMisc = new JsonObject();
         defaultMisc.addProperty("language", "en_US");
-        JsonElement misc = pkgJson.get("misc").getAsJsonObject();
+        JsonElement misc = pkgJson.has("misc") ? pkgJson.get("misc").getAsJsonObject() : null;
         mnfst.setMisc(new JsonWrapper(misc == null ? defaultMisc : misc));
 
         mnfst.setErrors(new JsonWrapper(errors));

--- a/src/main/java/edu/cmu/oli/content/resource/builders/ContentPkgJsonReader.java
+++ b/src/main/java/edu/cmu/oli/content/resource/builders/ContentPkgJsonReader.java
@@ -78,10 +78,18 @@ public final class ContentPkgJsonReader {
         JsonElement preferences = pkgJson.get("preferences");
         mnfst.setOptions(new JsonWrapper(preferences));
 
-        String language = pkgJson.has("language") ? pkgJson.get("language").getAsString() : null;
-        if (language != null) {
-            mnfst.setLanguage(language);
-        }
+        // JsonWrapper misc = mnfst.getMisc();
+        // JsonObject miscInfo = new JsonObject();
+        // if (misc != null) {
+        // miscInfo = misc.getJsonObject().getAsJsonObject();
+        // }
+        // miscInfo.addProperty("language", "en-US");
+        // mnfst.setMisc(new JsonWrapper(miscInfo));
+
+        JsonObject defaultMisc = new JsonObject();
+        defaultMisc.addProperty("language", "en_US");
+        JsonElement misc = pkgJson.get("misc").getAsJsonObject();
+        mnfst.setMisc(new JsonWrapper(misc == null ? defaultMisc : misc));
 
         mnfst.setErrors(new JsonWrapper(errors));
 

--- a/src/main/java/edu/cmu/oli/content/resource/builders/ContentPkgXmlReader.java
+++ b/src/main/java/edu/cmu/oli/content/resource/builders/ContentPkgXmlReader.java
@@ -102,12 +102,6 @@ public final class ContentPkgXmlReader {
         JsonElement elementToPreferenceSet = elementToPreferenceSet(prefsElmnt);
         mnfstBuilder.add("preferences", elementToPreferenceSet);
 
-        // Language
-        Element pkgLanguageElmnt = pkgElmnt.getChild("language");
-        if (pkgLanguageElmnt != null) {
-            mnfstBuilder.addProperty("language", pkgLanguageElmnt == null ? null : pkgLanguageElmnt.getTextNormalize());
-        }
-
         return mnfstBuilder;
     }
 

--- a/src/main/java/edu/cmu/oli/content/resource/builders/ContentPkgXmlWriter.java
+++ b/src/main/java/edu/cmu/oli/content/resource/builders/ContentPkgXmlWriter.java
@@ -173,13 +173,6 @@ public final class ContentPkgXmlWriter {
             }
         }
 
-        // Language
-        if (contentPkg.getLanguage() != null) {
-            Element pkgLanguageElmnt = new Element("language");
-            pkgLanguageElmnt.setText(contentPkg.getLanguage());
-            pkgElmnt.addContent(pkgLanguageElmnt);
-        }
-
         return pkgElmnt;
     }
 }

--- a/src/main/java/edu/cmu/oli/content/resource/builders/ContentPkgXmlWriter.java
+++ b/src/main/java/edu/cmu/oli/content/resource/builders/ContentPkgXmlWriter.java
@@ -175,7 +175,7 @@ public final class ContentPkgXmlWriter {
 
         // Language
         if (contentPkg.getLanguage() != null) {
-            Element pkgLanguageElmnt = new Element("langauge");
+            Element pkgLanguageElmnt = new Element("language");
             pkgLanguageElmnt.setText(contentPkg.getLanguage());
             pkgElmnt.addContent(pkgLanguageElmnt);
         }


### PR DESCRIPTION
client branch - same name, `language-hotfix`

Deploying courses causes a build error.

The main change is to go from saving the default/chosen foreign language from the language element on the content_package table and XML to a new misc JSON field in the database. The client had to be changed to use this new field.