### PR TITLE
Updated threadpooling to fix out of memory errors

### DIFF
--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/AnalyticsResource.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/AnalyticsResource.java
@@ -1,6 +1,6 @@
 package edu.cmu.oli.content.boundary.endpoints;
 
-import com.airhacks.porcupine.execution.boundary.Dedicated;
+import edu.cmu.oli.content.configuration.DedicatedExecutor;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import edu.cmu.oli.content.AppUtils;
@@ -45,7 +45,7 @@ public class AnalyticsResource {
     AppSecurityContextFactory appSecurityContextFactory;
 
     @Inject
-    @Dedicated("AnalyticsResourceApiExecutor")
+    @DedicatedExecutor("AnalyticsResourceApiExecutor")
     ExecutorService executor;
 
     @Context

--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/ContentPackageResource.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/ContentPackageResource.java
@@ -1,6 +1,6 @@
 package edu.cmu.oli.content.boundary.endpoints;
 
-import com.airhacks.porcupine.execution.boundary.Dedicated;
+import edu.cmu.oli.content.configuration.DedicatedExecutor;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
@@ -61,7 +61,7 @@ public class ContentPackageResource {
         Instance<Configurations> configuration;
 
         @Inject
-        @Dedicated("packagesResourceApiExecutor")
+        @DedicatedExecutor("packagesResourceApiExecutor")
         ExecutorService executor;
 
         @Context

--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/ContentResource.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/ContentResource.java
@@ -1,6 +1,6 @@
 package edu.cmu.oli.content.boundary.endpoints;
 
-import com.airhacks.porcupine.execution.boundary.Dedicated;
+import edu.cmu.oli.content.configuration.DedicatedExecutor;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
@@ -47,7 +47,7 @@ public class ContentResource {
     private ContentResourceManager pm;
 
     @Inject
-    @Dedicated("resourcesApiExecutor")
+    @DedicatedExecutor("resourcesApiExecutor")
     ExecutorService mes;
 
     @Inject

--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/DeveloperResource.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/DeveloperResource.java
@@ -1,6 +1,6 @@
 package edu.cmu.oli.content.boundary.endpoints;
 
-import com.airhacks.porcupine.execution.boundary.Dedicated;
+import edu.cmu.oli.content.configuration.DedicatedExecutor;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import edu.cmu.oli.content.AppUtils;
@@ -39,7 +39,7 @@ public class DeveloperResource {
     private DeveloperResourceManager pm;
 
     @Inject
-    @Dedicated("developersResourceApiExecutor")
+    @DedicatedExecutor("developersResourceApiExecutor")
     ExecutorService mes;
 
     @Context

--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/EdgeResource.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/EdgeResource.java
@@ -1,6 +1,6 @@
 package edu.cmu.oli.content.boundary.endpoints;
 
-import com.airhacks.porcupine.execution.boundary.Dedicated;
+import edu.cmu.oli.content.configuration.DedicatedExecutor;
 import com.google.gson.JsonElement;
 
 import edu.cmu.oli.content.AppUtils;
@@ -60,7 +60,7 @@ public class EdgeResource {
     EdgeResourceManager wcm;
 
     @Inject
-    @Dedicated("edgesApiExecutor")
+    @DedicatedExecutor("edgesApiExecutor")
     ExecutorService mes;
 
     @Inject

--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/LDModelResource.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/LDModelResource.java
@@ -1,6 +1,6 @@
 package edu.cmu.oli.content.boundary.endpoints;
 
-import com.airhacks.porcupine.execution.boundary.Dedicated;
+import edu.cmu.oli.content.configuration.DedicatedExecutor;
 import com.google.gson.JsonElement;
 import edu.cmu.oli.content.AppUtils;
 import edu.cmu.oli.content.boundary.ExceptionHandler;
@@ -50,7 +50,7 @@ public class LDModelResource {
         LDModelResourceManager ldModelResourceManager;
 
         @Inject
-        @Dedicated("webcontentsApiExecutor")
+        @DedicatedExecutor("webcontentsApiExecutor")
         ExecutorService mes;
 
         @Inject

--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/LockResource.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/LockResource.java
@@ -1,6 +1,6 @@
 package edu.cmu.oli.content.boundary.endpoints;
 
-import com.airhacks.porcupine.execution.boundary.Dedicated;
+import edu.cmu.oli.content.configuration.DedicatedExecutor;
 import com.google.gson.JsonElement;
 import edu.cmu.oli.content.AppUtils;
 import edu.cmu.oli.content.boundary.ExceptionHandler;
@@ -39,7 +39,7 @@ public class LockResource {
     private LockResourceManager lm;
 
     @Inject
-    @Dedicated("locksResourceApiExecutor")
+    @DedicatedExecutor("locksResourceApiExecutor")
     ExecutorService mes;
 
     @Context

--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/LongPollResource.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/LongPollResource.java
@@ -1,6 +1,6 @@
 package edu.cmu.oli.content.boundary.endpoints;
 
-import com.airhacks.porcupine.execution.boundary.Dedicated;
+import edu.cmu.oli.content.configuration.DedicatedExecutor;
 import com.google.gson.Gson;
 import edu.cmu.oli.content.AppUtils;
 import edu.cmu.oli.content.boundary.ExceptionHandler;
@@ -39,7 +39,7 @@ public class LongPollResource {
     private LongPollController longPollController;
 
     @Inject
-    @Dedicated("pollsResourceApiExecutor")
+    @DedicatedExecutor("pollsResourceApiExecutor")
     ExecutorService executor;
 
     @POST

--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/ResourceDelivery.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/ResourceDelivery.java
@@ -1,6 +1,6 @@
 package edu.cmu.oli.content.boundary.endpoints;
 
-import com.airhacks.porcupine.execution.boundary.Dedicated;
+import edu.cmu.oli.content.configuration.DedicatedExecutor;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
@@ -45,7 +45,7 @@ public class ResourceDelivery {
         private ResourceDeliveryManager pm;
 
         @Inject
-        @Dedicated("resourcesApiExecutor")
+        @DedicatedExecutor("resourcesApiExecutor")
         ExecutorService mes;
 
         @Inject

--- a/src/main/java/edu/cmu/oli/content/boundary/endpoints/WebResource.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/endpoints/WebResource.java
@@ -1,6 +1,6 @@
 package edu.cmu.oli.content.boundary.endpoints;
 
-import com.airhacks.porcupine.execution.boundary.Dedicated;
+import edu.cmu.oli.content.configuration.DedicatedExecutor;
 import com.google.gson.JsonElement;
 import edu.cmu.oli.content.AppUtils;
 import edu.cmu.oli.content.boundary.ExceptionHandler;
@@ -53,7 +53,7 @@ public class WebResource {
         WebResourceManager wcm;
 
         @Inject
-        @Dedicated("webcontentsApiExecutor")
+        @DedicatedExecutor("webcontentsApiExecutor")
         ExecutorService mes;
 
         @Inject

--- a/src/main/java/edu/cmu/oli/content/boundary/managers/AnalyticsResourceManager.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/managers/AnalyticsResourceManager.java
@@ -1,11 +1,11 @@
 package edu.cmu.oli.content.boundary.managers;
 
-import com.airhacks.porcupine.execution.boundary.Dedicated;
 import com.google.gson.*;
 import com.google.gson.reflect.TypeToken;
 import edu.cmu.oli.content.AppUtils;
 import edu.cmu.oli.content.ResourceException;
 import edu.cmu.oli.content.analytics.DatasetBuilder;
+import edu.cmu.oli.content.configuration.DedicatedExecutor;
 import edu.cmu.oli.content.logging.Logging;
 import edu.cmu.oli.content.models.persistance.entities.*;
 import edu.cmu.oli.content.security.*;
@@ -47,7 +47,7 @@ public class AnalyticsResourceManager {
     DatasetBuilder datasetBuilder;
 
     @Inject
-    @Dedicated("analyticsresourceApiExecutor")
+    @DedicatedExecutor("analyticsresourceApiExecutor")
     ExecutorService es;
 
     @Inject

--- a/src/main/java/edu/cmu/oli/content/boundary/managers/ContentPackageManager.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/managers/ContentPackageManager.java
@@ -45,7 +45,7 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import com.airhacks.porcupine.execution.boundary.Dedicated;
+import edu.cmu.oli.content.configuration.DedicatedExecutor;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -142,12 +142,14 @@ public class ContentPackageManager {
     XmlToContentPackage xmlToContentPackage;
 
     @Inject
-    @Dedicated("svnExecutor")
+    @DedicatedExecutor("svnExecutor")
     ExecutorService svnExecutor;
 
     @Inject
-    @Dedicated("versionBatchExec")
+    @DedicatedExecutor("versionBatchExec")
     ExecutorService versionExec;
+
+    static ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 
     @Inject
     DeployController deployController;
@@ -827,7 +829,7 @@ public class ContentPackageManager {
                 revsMap.put(resource.getTransientRev(), resource.getGuid());
             }
 
-            ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
             scheduler.schedule(() -> {
                 Set<String> jobIds = new HashSet<>(jobs.keySet());
 

--- a/src/main/java/edu/cmu/oli/content/boundary/managers/ContentResourceManager.java
+++ b/src/main/java/edu/cmu/oli/content/boundary/managers/ContentResourceManager.java
@@ -1,6 +1,6 @@
 package edu.cmu.oli.content.boundary.managers;
 
-import com.airhacks.porcupine.execution.boundary.Dedicated;
+import edu.cmu.oli.content.configuration.DedicatedExecutor;
 import com.google.common.collect.Iterables;
 import com.google.gson.*;
 import edu.cmu.oli.assessment.builders.Assessment2Transform;
@@ -107,7 +107,7 @@ public class ContentResourceManager {
     EdgesController edgesController;
 
     @Inject
-    @Dedicated("svnExecutor")
+    @DedicatedExecutor("svnExecutor")
     ExecutorService svnExecutor;
 
     public JsonElement fetchResource(AppSecurityContext session, String packageIdOrGuid, String resourceId) {
@@ -404,7 +404,6 @@ public class ContentResourceManager {
             }
 
             JsonArray contentItems = questionBody.get("#array").getAsJsonArray();
-            ;
 
             for (JsonElement contentItem : contentItems) {
                 boolean isCustom = contentItem.getAsJsonObject().has("custom");

--- a/src/main/java/edu/cmu/oli/content/configuration/DedicatedExecutor.java
+++ b/src/main/java/edu/cmu/oli/content/configuration/DedicatedExecutor.java
@@ -1,0 +1,18 @@
+package edu.cmu.oli.content.configuration;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.enterprise.util.Nonbinding;
+import javax.inject.Qualifier;
+
+@Qualifier
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DedicatedExecutor {
+    String DEFAULT = "-";
+
+    @Nonbinding
+    String value() default "-";
+}
+

--- a/src/main/java/edu/cmu/oli/content/configuration/ExecutorExposer.java
+++ b/src/main/java/edu/cmu/oli/content/configuration/ExecutorExposer.java
@@ -1,0 +1,147 @@
+package edu.cmu.oli.content.configuration;
+import com.airhacks.porcupine.configuration.control.ExecutorConfigurator;
+import com.airhacks.porcupine.execution.control.ExecutorConfiguration;
+import com.airhacks.porcupine.execution.control.InstrumentedThreadPoolExecutor;
+import com.airhacks.porcupine.execution.control.PipelineStore;
+import com.airhacks.porcupine.execution.entity.Pipeline;
+import com.airhacks.porcupine.execution.entity.Rejection;
+import com.airhacks.porcupine.execution.entity.Statistics;
+import edu.cmu.oli.content.logging.Logging;
+import org.slf4j.Logger;
+
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.Annotated;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class ExecutorExposer {
+    @Inject
+    @Logging
+    Logger log;
+
+    @Inject
+    Event<Rejection> rejections;
+    @Inject
+    PipelineStore ps;
+    @Inject
+    ExecutorConfigurator ec;
+
+    public ExecutorExposer() {
+    }
+
+    public void onRejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+        Pipeline pipeline = this.findPipeline(executor);
+        pipeline.taskRejected();
+        this.rejections.fire(new Rejection(pipeline.getStatistics(), r.getClass().getName()));
+    }
+
+    @Produces
+    @DedicatedExecutor
+    public ExecutorService exposeExecutorService(InjectionPoint ip) {
+        String pipelineName = this.getPipelineName(ip);
+        Pipeline existingPipeline = this.ps.get(pipelineName);
+        if (existingPipeline != null) {
+            log.info("Pipeline Old: "+ pipelineName);
+            return existingPipeline.getExecutor();
+        } else {
+            log.info("Pipeline New: "+ pipelineName);
+            ExecutorConfiguration config = this.ec.forPipeline(pipelineName);
+            RejectedExecutionHandler rejectedExecutionHandler = config.getRejectedExecutionHandler();
+            if (rejectedExecutionHandler == null) {
+                rejectedExecutionHandler = this::onRejectedExecution;
+            }
+
+            InstrumentedThreadPoolExecutor threadPoolExecutor = this.createThreadPoolExecutor(config, rejectedExecutionHandler, pipelineName);
+            this.ps.put(pipelineName, new Pipeline(pipelineName, threadPoolExecutor));
+            return threadPoolExecutor;
+        }
+    }
+
+    InstrumentedThreadPoolExecutor createThreadPoolExecutor(ExecutorConfiguration config, RejectedExecutionHandler rejectedExecutionHandler, String name) {
+        int corePoolSize = config.getCorePoolSize();
+        int keepAliveTime = config.getKeepAliveTime();
+        int maxPoolSize = config.getMaxPoolSize();
+        int queueCapacity = config.getQueueCapacity();
+        Object queue;
+        if (queueCapacity > 0) {
+            queue = new ArrayBlockingQueue(queueCapacity);
+        } else {
+            queue = new SynchronousQueue();
+        }
+
+
+        InstrumentedThreadPoolExecutor threadPoolExecutor = new InstrumentedThreadPoolExecutor(corePoolSize, maxPoolSize, (long)keepAliveTime, TimeUnit.SECONDS, (BlockingQueue)queue, new DThreadFactory(name), rejectedExecutionHandler);
+        return threadPoolExecutor;
+    }
+
+    @Produces
+    @DedicatedExecutor
+    public Statistics exposeStatistics(InjectionPoint ip) {
+        String name = this.getPipelineName(ip);
+        return this.ps.getStatistics(name);
+    }
+
+    @Produces
+    public List<Statistics> getAllStatistics() {
+        return this.ps.getAllStatistics();
+    }
+
+    String getPipelineName(InjectionPoint ip) {
+        Annotated annotated = ip.getAnnotated();
+        DedicatedExecutor dedicated = (DedicatedExecutor)annotated.getAnnotation(DedicatedExecutor.class);
+        String name;
+        if (dedicated != null && !"-".equals(dedicated.value())) {
+            name = dedicated.value();
+        } else {
+            name = ip.getMember().getName();
+        }
+
+        return name;
+    }
+
+    Pipeline findPipeline(ThreadPoolExecutor executor) {
+        return (Pipeline)this.ps.pipelines().stream().filter((p) -> {
+            return p.manages(executor);
+        }).findFirst().orElse((Pipeline)null);
+    }
+
+    private static class DThreadFactory implements ThreadFactory {
+        private static final AtomicInteger poolNumber = new AtomicInteger(1);
+        private final ThreadGroup group;
+        private final AtomicInteger threadNumber = new AtomicInteger(1);
+        private final String namePrefix;
+
+        DThreadFactory(String name) {
+            SecurityManager s = System.getSecurityManager();
+            group = (s != null) ? s.getThreadGroup() :
+                    Thread.currentThread().getThreadGroup();
+            namePrefix = "pool-" + name +
+                    poolNumber.getAndIncrement() +
+                    "-thread-";
+        }
+
+        public Thread newThread(Runnable r) {
+            Thread t = new Thread(group, r,
+                    namePrefix + threadNumber.getAndIncrement(),
+                    0);
+            if (t.isDaemon())
+                t.setDaemon(false);
+            if (t.getPriority() != Thread.NORM_PRIORITY)
+                t.setPriority(Thread.NORM_PRIORITY);
+            return t;
+        }
+    }
+}

--- a/src/main/java/edu/cmu/oli/content/contentfiles/DirectorysWatcher.java
+++ b/src/main/java/edu/cmu/oli/content/contentfiles/DirectorysWatcher.java
@@ -5,7 +5,7 @@
  */
 package edu.cmu.oli.content.contentfiles;
 
-import com.airhacks.porcupine.execution.boundary.Dedicated;
+import edu.cmu.oli.content.configuration.DedicatedExecutor;
 import edu.cmu.oli.content.configuration.ConfigurationCache;
 import edu.cmu.oli.content.configuration.Configurations;
 import edu.cmu.oli.content.logging.Logging;
@@ -39,12 +39,14 @@ import java.util.concurrent.TimeUnit;
 @ApplicationScoped
 public class DirectorysWatcher {
 
+    private ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+
     @Inject
     @Logging
     Logger log;
 
     @Inject
-    @Dedicated("contentFilesProcessor")
+    @DedicatedExecutor("contentFilesProcessor")
     ExecutorService rscExec;
 
     @Inject
@@ -197,7 +199,7 @@ public class DirectorysWatcher {
             String message = "Error while processing course content package import " + packageFolder.toString();
             log.error(message, e);
         }
-        ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
         scheduler.schedule(() -> {
             WebContentFolderCleanup webContentFolderCleanup = null;
             try {

--- a/src/main/java/edu/cmu/oli/content/contentfiles/MigrationProcessor.java
+++ b/src/main/java/edu/cmu/oli/content/contentfiles/MigrationProcessor.java
@@ -1,6 +1,6 @@
 package edu.cmu.oli.content.contentfiles;
 
-import com.airhacks.porcupine.execution.boundary.Dedicated;
+import edu.cmu.oli.content.configuration.DedicatedExecutor;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import edu.cmu.oli.content.AppUtils;
@@ -40,8 +40,10 @@ public class MigrationProcessor {
     Logger log;
 
     @Inject
-    @Dedicated("migrationExec")
+    @DedicatedExecutor("migrationExec")
     ExecutorService rscExec;
+
+    static ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 
     @Inject
     @ConfigurationCache
@@ -135,7 +137,7 @@ public class MigrationProcessor {
     }
 
     private void webContentFolderCleanup() {
-        ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
         scheduler.schedule(() -> {
             WebContentFolderCleanup webContentFolderCleanup = null;
             try {

--- a/src/main/java/edu/cmu/oli/content/contentfiles/RevisionMigrationProcessor.java
+++ b/src/main/java/edu/cmu/oli/content/contentfiles/RevisionMigrationProcessor.java
@@ -24,7 +24,7 @@
 
 package edu.cmu.oli.content.contentfiles;
 
-import com.airhacks.porcupine.execution.boundary.Dedicated;
+import edu.cmu.oli.content.configuration.DedicatedExecutor;
 import edu.cmu.oli.content.configuration.ConfigurationCache;
 import edu.cmu.oli.content.configuration.Configurations;
 import edu.cmu.oli.content.logging.Logging;
@@ -58,7 +58,7 @@ public class RevisionMigrationProcessor {
     Logger log;
 
     @Inject
-    @Dedicated("revMigrationExec")
+    @DedicatedExecutor("revMigrationExec")
     ExecutorService rscExec;
 
     @Inject

--- a/src/main/java/edu/cmu/oli/content/contentfiles/readers/XmlToContentPackage.java
+++ b/src/main/java/edu/cmu/oli/content/contentfiles/readers/XmlToContentPackage.java
@@ -43,6 +43,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -78,6 +79,8 @@ public class XmlToContentPackage {
     ContentPackage contentPackage;
 
     Map<String, String> oldResourceGuids = new HashMap<>();
+
+    static ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2);
 
     public void setContentPackage(ContentPackage contentPackage) {
         this.contentPackage = contentPackage;
@@ -566,7 +569,7 @@ public class XmlToContentPackage {
             }
             final String sourceLocation = contentPackage.getSourceLocation();
 
-            Executors.newSingleThreadScheduledExecutor().schedule(() -> doProcessLDmodelFiles(guid, sourceLocation), 2, TimeUnit.SECONDS);
+            scheduler.schedule(() -> doProcessLDmodelFiles(guid, sourceLocation), 2, TimeUnit.SECONDS);
 
             log.info("Done processing content import for package=" + contentPackage.getId() + " version=" + contentPackage.getVersion() + " location=" + contentPackage.getSourceLocation());
         } catch (IOException e) {
@@ -641,7 +644,7 @@ public class XmlToContentPackage {
                 return;
             }
         }
-        Executors.newSingleThreadScheduledExecutor().schedule(() -> doLDImport(packageGuid, skillsModel, problemsModel, losModel, retry), 5, TimeUnit.SECONDS);
+        scheduler.schedule(() -> doLDImport(packageGuid, skillsModel, problemsModel, losModel, retry), 5, TimeUnit.SECONDS);
     }
 
     public class FNode {

--- a/src/main/java/edu/cmu/oli/content/controllers/EdgesController.java
+++ b/src/main/java/edu/cmu/oli/content/controllers/EdgesController.java
@@ -29,6 +29,8 @@ import java.util.concurrent.TimeUnit;
 @Stateless
 public class EdgesController {
 
+    private static ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+
     @Inject
     @Logging
     Logger log;
@@ -99,7 +101,7 @@ public class EdgesController {
     }
 
     private void doValidateAsync(String pkgGuid, Integer retryCnt) {
-        ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
         scheduler.schedule(() -> {
             try {
                 EdgesController edgesController = (EdgesController)

--- a/src/main/java/edu/cmu/oli/content/controllers/LDModelControllerImpl.java
+++ b/src/main/java/edu/cmu/oli/content/controllers/LDModelControllerImpl.java
@@ -1,6 +1,6 @@
 package edu.cmu.oli.content.controllers;
 
-import com.airhacks.porcupine.execution.boundary.Dedicated;
+import edu.cmu.oli.content.configuration.DedicatedExecutor;
 import com.google.gson.*;
 import edu.cmu.oli.content.AppUtils;
 import edu.cmu.oli.content.ContentServiceException;
@@ -75,7 +75,7 @@ public class LDModelControllerImpl implements LDModelController {
     Instance<Configurations> configuration;
 
     @Inject
-    @Dedicated("svnExecutor")
+    @DedicatedExecutor("svnExecutor")
     ExecutorService svnExecutor;
 
     @Override


### PR DESCRIPTION
This PR addresses the memory leak issue caused by weak thread pool tracking and management. It moves all one-of pools into global scope and switches all managed pools into application scoped bean.




Risk: low
Stability: high