### PR TITLE
HOTFIX 0.41.0 - Fix package metadata editing

### DIFF
--- a/src/main/java/edu/cmu/oli/content/resource/builders/OptionsWriter.java
+++ b/src/main/java/edu/cmu/oli/content/resource/builders/OptionsWriter.java
@@ -59,12 +59,14 @@ public final class OptionsWriter {
 
         // Preferences
         JsonArray preferences = prefSet.getAsJsonArray("preferences");
-        preferences.forEach((val) -> {
-            Element element = preferenceToElement(val, ns);
-            if (element != null) {
-                setElmnt.addContent(element);
-            }
-        });
+        if (preferences != null) {
+            preferences.forEach((val) -> {
+                Element element = preferenceToElement(val, ns);
+                if (element != null) {
+                    setElmnt.addContent(element);
+                }
+            });
+        }
 
         return setElmnt;
     }


### PR DESCRIPTION
**Problem**:
The title for the course Statistics 5.1 for UC Davis can not be edited.
https://echo.oli.cmu.edu/#UCDavisStats-5.1

**Solution**:
Some older courses imported into Echo do not have package metadata that conforms to the assumptions made when the server code was written to update it. 

In this case, a null pointer exception was being thrown when the server tried to update the package options (specifically, the course preferences).

I added a null check so that it only continues parsing preferences if preferences are not empty.

To test, I deployed the branch to Shattrath and imported the UC Davis stats course that doesn't work on Echo, and I can edit the title now.

**Wireframe/Screenshot**:
None.

**Risk**:
Low

**Areas of concern**:
None