### PR TITLE
Authoring 2257 empty preferences bug

### DIFF
--- a/src/main/java/edu/cmu/oli/content/models/persistance/JsonWrapper.java
+++ b/src/main/java/edu/cmu/oli/content/models/persistance/JsonWrapper.java
@@ -34,9 +34,7 @@ public class JsonWrapper implements Externalizable {
     }
 
     public JsonElement serializeJson() {
-        JsonObject jsonObject = new JsonObject();
-        jsonObject.add("jsonObject", jp.parse(jsonString));
-        return jsonObject;
+        return jp.parse(jsonString);
     }
 
     public void setJsonObject(JsonElement jsonObject) {

--- a/src/main/java/edu/cmu/oli/content/resource/builders/OptionsWriter.java
+++ b/src/main/java/edu/cmu/oli/content/resource/builders/OptionsWriter.java
@@ -1,6 +1,9 @@
 package edu.cmu.oli.content.resource.builders;
 
-import com.google.gson.*;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
 import org.jdom2.Element;
 import org.jdom2.Namespace;
 import org.slf4j.Logger;
@@ -48,11 +51,12 @@ public final class OptionsWriter {
 
         final Namespace ns = nsi;
         JsonObject prefSet = (JsonObject) prefSeti;
-        if(prefSet.has("jsonObject")){
-            prefSet = prefSet.getAsJsonObject("jsonObject");
+        // Preferences
+        JsonArray preferences = prefSet.getAsJsonArray("preferences");
+        if (preferences == null) {
+            return null;
         }
 
-        log.info("Preference set info: " + new Gson().toJson(prefSet));
         // Preference set
         Element setElmnt = new Element("preferences", ns);
 
@@ -61,16 +65,12 @@ public final class OptionsWriter {
             setElmnt.setAttribute("guid", prefSet.get("@guid").getAsString());
         }
 
-        // Preferences
-        JsonArray preferences = prefSet.getAsJsonArray("preferences");
-        if (preferences != null) {
-            preferences.forEach((val) -> {
-                Element element = preferenceToElement(val, ns);
-                if (element != null) {
-                    setElmnt.addContent(element);
-                }
-            });
-        }
+        preferences.forEach((val) -> {
+            Element element = preferenceToElement(val, ns);
+            if (element != null) {
+                setElmnt.addContent(element);
+            }
+        });
 
         return setElmnt;
     }

--- a/src/main/java/edu/cmu/oli/content/resource/builders/OptionsWriter.java
+++ b/src/main/java/edu/cmu/oli/content/resource/builders/OptionsWriter.java
@@ -1,11 +1,10 @@
 package edu.cmu.oli.content.resource.builders;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonNull;
-import com.google.gson.JsonObject;
+import com.google.gson.*;
 import org.jdom2.Element;
 import org.jdom2.Namespace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Methods for generating preference service XML.
@@ -13,7 +12,7 @@ import org.jdom2.Namespace;
  * @author Raphael Gachuhi
  */
 public final class OptionsWriter {
-
+    static final Logger log = LoggerFactory.getLogger(OptionsWriter.class);
     private static final String _PUBLIC_ID = "-//Carnegie Mellon University//DTD Preferences 1.0//EN";
     private static final String _SYSTEM_ID = "http://oli.cmu.edu/dtd/oli_preferences_1_0.dtd";
 
@@ -49,6 +48,11 @@ public final class OptionsWriter {
 
         final Namespace ns = nsi;
         JsonObject prefSet = (JsonObject) prefSeti;
+        if(prefSet.has("jsonObject")){
+            prefSet = prefSet.getAsJsonObject("jsonObject");
+        }
+
+        log.info("Preference set info: " + new Gson().toJson(prefSet));
         // Preference set
         Element setElmnt = new Element("preferences", ns);
 


### PR DESCRIPTION
This PR is a fix for a json serialization assumption which is the root cause to a class of problem whereby editing any aspect of a course package attributes (title, description etc) can end up with an invalid package.xml file, especially one that has a preference list.