### PR TITLE
Authoring 2269 image hotspot fix

### DIFF
--- a/src/main/java/edu/cmu/oli/assessment/builders/Assessment2Transform.java
+++ b/src/main/java/edu/cmu/oli/assessment/builders/Assessment2Transform.java
@@ -75,6 +75,11 @@ public class Assessment2Transform {
                         select.detach();
                         element.setAttribute(select);
                     }
+                    Attribute grading = next.getAttribute("grading");
+                    if (grading != null) {
+                        grading.detach();
+                        element.setAttribute(grading);
+                    }
                 });
             }
             if (inputs.hasNext()) {
@@ -87,7 +92,7 @@ public class Assessment2Transform {
                     }
 
                 });
-            } else if (inputRefs.hasNext()) {
+            } else if (inputRefs.hasNext() && !next.getName().equalsIgnoreCase("image_hotspot")) {
                 List<Element> refs = new ArrayList<>();
                 inputRefs.forEach(element -> refs.add(element));
                 for (int i = 0; i < refs.size(); i++) {
@@ -100,7 +105,7 @@ public class Assessment2Transform {
                         ty.setAttribute(select);
                     }
                 }
-            } else {
+            } else if (!next.getName().equalsIgnoreCase("image_hotspot")) {
                 Element input = next.getChild("input");
                 if (input == null) {
                     input = new Element(next.getName());
@@ -190,6 +195,14 @@ public class Assessment2Transform {
                 case "image_hotspot":
                     questionType.forEach(element -> {
                         element.setName("image_input");
+                        element.getAttributes().forEach(attribute -> {
+                            if (attribute.getName().equalsIgnoreCase("select") ||
+                                    attribute.getName().equalsIgnoreCase("grading")) {
+                                attribute.detach();
+                                ((Element) element.getParent()).setAttribute(attribute);
+                            }
+                        });
+
                     });
                     break;
                 default:

--- a/src/main/java/edu/cmu/oli/assessment/evaluators/MatcherByType.java
+++ b/src/main/java/edu/cmu/oli/assessment/evaluators/MatcherByType.java
@@ -30,6 +30,8 @@ import com.google.gson.JsonObject;
 import edu.cmu.oli.assessment.InputFormatException;
 import edu.cmu.oli.assessment.InteractionStyle;
 import edu.cmu.oli.assessment.PatternFormatException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -42,6 +44,7 @@ import java.util.regex.PatternSyntaxException;
  * @author Raphael Gachuhi
  */
 public class MatcherByType {
+    static final Logger log = LoggerFactory.getLogger(MatcherByType.class);
 
     JsonObject interaction;
 
@@ -74,6 +77,7 @@ public class MatcherByType {
             case ORDERING:
                 return ordering(pattern);
             case NUMERIC:
+                log.info("numeric");
                 return numeric(pattern);
             case IMAGE_HOTSPOT:
                 return imageHotSpot(pattern);
@@ -140,6 +144,7 @@ public class MatcherByType {
         // Precision
         int p = pattern.indexOf("#");
         if (p >= 0) {
+            log.info("precision 1");
             int precision;
             try {
                 precision = Integer.parseInt(pattern.substring(p + 1));

--- a/src/main/java/edu/cmu/oli/assessment/evaluators/MatcherByType.java
+++ b/src/main/java/edu/cmu/oli/assessment/evaluators/MatcherByType.java
@@ -30,8 +30,6 @@ import com.google.gson.JsonObject;
 import edu.cmu.oli.assessment.InputFormatException;
 import edu.cmu.oli.assessment.InteractionStyle;
 import edu.cmu.oli.assessment.PatternFormatException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -44,8 +42,6 @@ import java.util.regex.PatternSyntaxException;
  * @author Raphael Gachuhi
  */
 public class MatcherByType {
-    static final Logger log = LoggerFactory.getLogger(MatcherByType.class);
-
     JsonObject interaction;
 
     public MatcherByType(JsonObject interaction) {
@@ -77,7 +73,6 @@ public class MatcherByType {
             case ORDERING:
                 return ordering(pattern);
             case NUMERIC:
-                log.info("numeric");
                 return numeric(pattern);
             case IMAGE_HOTSPOT:
                 return imageHotSpot(pattern);
@@ -144,7 +139,6 @@ public class MatcherByType {
         // Precision
         int p = pattern.indexOf("#");
         if (p >= 0) {
-            log.info("precision 1");
             int precision;
             try {
                 precision = Integer.parseInt(pattern.substring(p + 1));

--- a/src/main/java/edu/cmu/oli/assessment/evaluators/PrecisionMatcher.java
+++ b/src/main/java/edu/cmu/oli/assessment/evaluators/PrecisionMatcher.java
@@ -24,9 +24,13 @@
 
 package edu.cmu.oli.assessment.evaluators;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.math.BigDecimal;
 
 public class PrecisionMatcher implements ResponseMatcher<BigDecimal> {
+    static final Logger log = LoggerFactory.getLogger(PrecisionMatcher.class);
     private int precision;
 
     public PrecisionMatcher(int precision) {
@@ -52,6 +56,7 @@ public class PrecisionMatcher implements ResponseMatcher<BigDecimal> {
     }
 
     public boolean matches(BigDecimal response) {
+        log.info("value= "+ response + "match precision:= "+response.precision() +" vs " + precision + " vs scale= " + response.scale());
         if (response == null) return false;
         return (precision == response.precision());
     }

--- a/src/main/java/edu/cmu/oli/assessment/evaluators/PrecisionMatcher.java
+++ b/src/main/java/edu/cmu/oli/assessment/evaluators/PrecisionMatcher.java
@@ -24,13 +24,9 @@
 
 package edu.cmu.oli.assessment.evaluators;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.math.BigDecimal;
 
 public class PrecisionMatcher implements ResponseMatcher<BigDecimal> {
-    static final Logger log = LoggerFactory.getLogger(PrecisionMatcher.class);
     private int precision;
 
     public PrecisionMatcher(int precision) {
@@ -56,7 +52,6 @@ public class PrecisionMatcher implements ResponseMatcher<BigDecimal> {
     }
 
     public boolean matches(BigDecimal response) {
-        log.info("value= "+ response + "match precision:= "+response.precision() +" vs " + precision + " vs scale= " + response.scale());
         if (response == null) return false;
         return (precision == response.precision());
     }

--- a/src/main/java/edu/cmu/oli/content/controllers/LDModelControllerImpl.java
+++ b/src/main/java/edu/cmu/oli/content/controllers/LDModelControllerImpl.java
@@ -1022,8 +1022,12 @@ public class LDModelControllerImpl implements LDModelController {
         JsonArray stepArray = partAsJsonObject.getAsJsonArray("#array");
 
         boolean skillRefAlreadyExists = false;
+        int index = -1;
         try {
             for (JsonElement next : stepArray) {
+                if(next.isJsonObject() && next.getAsJsonObject().has("title")){
+                    index = 0;
+                }
                 if (next.isJsonObject() && next.getAsJsonObject().has("skillref") && next.getAsJsonObject()
                         .get("skillref").getAsJsonObject().get("@idref").getAsString().equals(skillId)) {
                     skillRefAlreadyExists = true;
@@ -1034,7 +1038,7 @@ public class LDModelControllerImpl implements LDModelController {
             log.error(AppUtils.gsonBuilder().create().toJson(part));
             throw e;
         }
-        tagWithSkill(skillId, part, stepArray, -1, skillRefAlreadyExists);
+        tagWithSkill(skillId, part, stepArray, index, skillRefAlreadyExists);
     }
 
     private void findAllParts(JsonElement content, List<JsonElement> parts) {

--- a/src/test/java/edu/cmu/oli/content/resource/builders/ImageHotspotTransformTest.java
+++ b/src/test/java/edu/cmu/oli/content/resource/builders/ImageHotspotTransformTest.java
@@ -1,0 +1,50 @@
+package edu.cmu.oli.content.resource.builders;
+
+import edu.cmu.oli.assessment.builders.Assessment2Transform;
+import edu.cmu.oli.content.contentfiles.utils.ResourceTestPipeline;
+import org.jdom2.Document;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Raphael Gachuhi
+ */
+public class ImageHotspotTransformTest {
+
+    private Assessment2Transform cut;
+
+    @Before
+    public void setUp() {
+        cut = new Assessment2Transform();
+    }
+
+    @Test
+    public void transformToUnified() throws Exception {
+        final List<Boolean> errors = new ArrayList<>();
+        final ResourceTestPipeline pipeline = new ResourceTestPipeline(
+                ImageHotspotTransformTest.class.getResource("test-resources/_m4_assess.xml"),
+                "x-oli-assessment2") {
+
+            @Override
+            public Document afterStringToDoc(final Document doc) {
+                cut.transformToUnified(doc.getRootElement());
+                return super.afterStringToDoc(doc);
+            }
+
+            @Override
+            public Document afterJsonToDoc(Document doc) {
+                cut.transformFromUnified(doc.getRootElement());
+                return super.afterJsonToDoc(doc);
+            }
+        };
+
+        pipeline.execute();
+
+        assertTrue(errors.isEmpty());
+    }
+}

--- a/src/test/resources/edu/cmu/oli/content/resource/builders/test-resources/_m4_assess.xml
+++ b/src/test/resources/edu/cmu/oli/content/resource/builders/test-resources/_m4_assess.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?> <!DOCTYPE assessment PUBLIC "-//Carnegie Mellon University//DTD Assessment MathML 2.4//EN" "http://oli.web.cmu.edu/dtd/oli_assessment_mathml_2_4.dtd">
+<assessment xmlns:cmd="http://oli.web.cmu.edu/content/metadata/2.1/" id="_m4_assess">
+    <title>Effects of Multiple Forces</title>
+    <page>
+        <numeric id="q1">
+            <body><p>Two forces are applied to the body via cables. Both forces act through the
+                point (x,y)=(3,2) and the line of action of the force F<sub>1</sub> passes
+                through (x,y)=(2,5). You are to replace the two cables by a single cable that is
+                produces the same effect on the body. </p><image src="../webcontent/statics_quiz4_image1.gif"/><p>First, deter mine the
+                components of the forces F<sub>1</sub> and F<sub>2</sub>:</p><ul>
+                <li><p>x-component of F<sub>1</sub> = <input_ref input="i1"/> N</p></li>
+                <li><p>y-component of F<sub>1</sub> = <input_ref input="i2"/> N</p></li>
+                <li><p>x-compo nent of F<sub>2</sub> = <input_ref input="i3"/> N</p></li>
+                <li><p>y-component of F<sub>2</sub> = <input_ref input="i4"/> N</p></li>
+            </ul></body>
+            <input id="i1"/>
+            <input id="i2"/>
+            <input id="i3"/>
+            <input id="i4"/>
+            <part id="p1">
+                <skillref idref="resolve_into_components"/>
+                <response name="-1.58" input="i1" match="(-1.659,-1.501)" score="5"/>
+                <response input="i1" match="*" score="0"/>
+                <no_response score="0"/>
+            </part>
+            <part id="p2">
+                <skillref idref="resolve_into_components"/>
+                <response name="4.74" input="i2" match="(4.503,4.977)" score="5"/>
+                <response input="i2" match="*" score="0"/>
+                <no_response score="0"/>
+            </part>
+            <part id="p3">
+                <skillref idref="resolve_into_components"/>
+                <response name="17" input="i3 " match="(16.15,17.85)" score="5"/>
+                <response input="i3" match="*" score="0"/>
+                <no_response score="0"/>
+            </part>
+            <part id="p4">
+                <skillref idref="resolve_into_components"/>
+                <response name="-10" input="i4" match="(-10.5,-9.5)" score="5"/>
+                <response input="i4" match="*" score="0"/>
+                <no_response score="0"/>
+            </part>
+        </numeric>
+        <numeric id="q2">
+            <body><p>What is the tension in the single replacement cable? <input_ref input="i1"/>
+                N</p></body>
+            <input id="i1"/>
+            <part id="p1">
+                <skillref idref="find_magnitude_given_components"/>
+                <response name="16.6" input="i1" match="(15.77,17.43)" score="15"/>
+                <response input="i1" match="*" score="0"/>
+                <no_response score="0"/>
+            </part>
+        </numeric>
+        <numeric id="q3">
+            <body><p>What is the angle α that the single replacement cable forms with the x axis?
+                (enter a positive number) <input_ref input="i1"/> degrees</p></body>
+            <input id="i1"/>
+            <part id="p1">
+                <skillref idref="find_angle_given_components"/>
+                <response name="18.5" input="i1" match="(17.575,19.425)" score="15"/>
+                <response name="341.5" input="i1" match="(324.425,358.575)" score="15"/>
+                <response input="i1" match="*" score="0"/>
+                <no_response score="0"/>
+            </part>
+        </numeric>
+        <image_hotspot id="q4" select="single">
+            <body><p>Indicate the direction of the single replacement cable by clicking on the
+                appropriate quadrant:</p><input_ref input="direction"/></body>
+            <image_input id="direction" src="../webcontent/statics_ quiz4_image2.gif" width="107"
+                         height="108">
+                <hotspot shape="rect" value="up_and_left" coords="0,0,53,52">Up and Left</hotspot>
+                <hotspot shape="rect" value="up_and_right" coords="54,0,107,52">Up and
+                    Right</hotspot>
+                <hotspot shape="rect" value="down_and_left" coords="0,53,53,105">Down and
+                    Left</hotspot>
+                <hotspot shape="rect" value="down_and_right" coords="54,53,107,105">Down and
+                    Right</hotspot>
+            </image_input>
+            <part id="p1">
+                <skillref idref="find_angle_given_components"/>
+                <response name="up and left" input="direction" match="up_and_left" score="0"/>
+                <response name="up and right" input="direction" match="up_and_right" score="0"/>
+                <response name="down and left" input="direction" match="dow n_and_left" score="0"/>
+                <response name="down and right" input="direction" match="down_and_right" score="5"/>
+                <no_response score="0"/>
+            </part>
+        </image_hotspot>
+    </page>
+    <page>
+        <content>
+            <p>Determine the moment created by the two forces about the point O.</p>
+            <image src="../webcontent/statics_quiz4_image3.gif"/>
+        </content>
+        <numeric id="q5">
+            <body><p>Magnitude of moment (enter positive number) = <input_ref input="i1"/>
+                lb-in</p></body>
+            <input id="i1"/>
+            <part id="p1">
+                <skillref idref="determine_moment"/>
+                <response name="10" input="i1" match="(9.5, 10.5)" score="10"/>
+                <response input="i1" match="*" score="0"/>
+                <no_response score="0"/>
+            </part>
+        </numeric>
+        <fill_in_the_blank id="q6">
+            <body><p>Sense of moment = <input_ref input="i1"/></p></body>
+            <input id="i1" shuffle="false">
+                <choice value="cw">CW</choice>
+                <choice value="ccw">CCW</choice>
+            </input>
+            <part id="p1">
+                <skillref idref="moment_sign_sense_relation"/>
+                <response name="CW" input="i1" match="cw " score="5"/>
+                <response name="CCW" input="i1" match="ccw" score="0"/>
+                <no_response score="0"/>
+            </part>
+        </fill_in_the_blank>
+    </page>
+    <page>
+        <content>
+            <p>Determine the moment of the force about the point O.</p>
+            <image src="../webcontent/stati cs_quiz4_image4.gif"/>
+        </content>
+        <numeric id="q7">
+            <body><p>Component of F perpendicular to OP = <input_ref input="i1"/> N</p></body>
+            <input id="i1"/>
+            <part id="p1">
+                <skillref idref="resolve_into_components"/>
+                <response name="15.32" input="i1" match="(14.554, 16.086)" score="15"/>
+                <response input="i1" match="*" score="0"/>
+                <no_response score="0"/>
+            </part>
+        </numeric>
+        <numeric id="q8">
+            <body><p>Magnitude of moment (enter positive number; pay attention to units) =
+                <input_ref input="i1"/> N-m</p></body>
+            <input id="i1"/>
+            <part id="p1">
+                <skillref idref="find_moment_arm"/>
+                <response name="7.66" input="i1" match="(7.277, 8.043)" score="15"/>
+                <response input="i1" match="*" score="0"/>
+                <no_response score="0"/>
+            </part>
+        </numeric>
+        <fill_in_the_blank id="q9">
+            <body><p>Sense of moment = <input_ref input="i1"/></p></body>
+            <input id="i1" shuffle="false">
+                <choice value="cw">CW</choice>
+                <choice value="ccw">CCW</choice>
+            </input>
+            <part id="p1">
+                <skillref idref="moment_sign_sense_relation"/>
+                <skillref idref="rotation_sense_of_force"/>
+                <response name="CW" input="i1" match="cw" score="0"/>
+                <response name="CCW" input="i1" match="ccw" score="5"/>
+                <no_response score="0"/>
+            </part>
+        </fill_in_the_blank>
+    </page>
+</assessment>


### PR DESCRIPTION
This PR fixes an issue with A2 to/from unified model transformation affecting image_hotspot type questions. It also addresses an issue with skills tagging where question parts have "title" tags. Now correctly locates the skills tag after title instead of incorrectly before title tag.