### PR TITLE
take a more passive approach to lock management

### DIFF
--- a/src/main/java/edu/cmu/oli/content/configuration/Configurations.java
+++ b/src/main/java/edu/cmu/oli/content/configuration/Configurations.java
@@ -22,7 +22,7 @@ public class Configurations {
     private String webContentVolume;
     private String themesRepository;
     private int transactionRetrys = 3;
-    private int editLockMaxDuration = 300000;
+    private int editLockMaxDuration = 1000 * 60 * 5; // 5 minutes
     private JsonObject developerAdmin;
     private JsonObject namespaces;
     private JsonArray themes;

--- a/src/main/java/edu/cmu/oli/content/models/ResourceEditLock.java
+++ b/src/main/java/edu/cmu/oli/content/models/ResourceEditLock.java
@@ -9,9 +9,6 @@ import edu.cmu.oli.content.AppUtils;
 public final class ResourceEditLock {
 
     @Expose
-    long lockMaxDuration = 1000L * 60L * 5L; // 5 minutes
-
-    @Expose
     String lockId;
 
     @Expose
@@ -24,24 +21,22 @@ public final class ResourceEditLock {
     @Expose
     long lockedAt;
 
-    public ResourceEditLock(long lockMaxDuration, String resourceId, String lockedBy, long lockedAt) {
+    public ResourceEditLock(String resourceId, String lockedBy, long lockedAt) {
         this.lockId = AppUtils.generateGUID();
-        this.lockMaxDuration = lockMaxDuration;
         this.resourceId = resourceId;
         this.lockedBy = lockedBy;
         this.lockedAt = lockedAt;
     }
 
-    public ResourceEditLock(String lockId, long lockMaxDuration, String resourceId, String lockedBy, long lockedAt) {
+    public ResourceEditLock(String lockId, String resourceId, String lockedBy, long lockedAt) {
         this.lockId = lockId;
-        this.lockMaxDuration = lockMaxDuration;
         this.resourceId = resourceId;
         this.lockedBy = lockedBy;
         this.lockedAt = lockedAt;
     }
 
     public ResourceEditLock withUpdatedLockedAt(long lockedAt) {
-        return new ResourceEditLock(this.lockId, this.lockMaxDuration, this.resourceId, this.lockedBy, lockedAt);
+        return new ResourceEditLock(this.lockId, this.resourceId, this.lockedBy, lockedAt);
     }
 
     public String getLockId() {


### PR DESCRIPTION
This PR adjusts the lock management approach to remove the server cleanup of expired locks, with the net result that a user will only ever see the "This editing session has expired" if another user has acquired the lock after the five minute expiration period. 

With this PR in place I have tested to ensure the following scenarios work correctly:

Scenario A: Extended Locks:
1. User A acquires a lock and makes some edits
2. User A walks away from computer for any amount of time exceeding 5 minutes, leaving the editor open
3. User A returns and makes another edit.  The logic detects that an existing expired lock from the same user is present so it simply allows that lock to be updated and the user can continue to make edits.

Scenario B: Expired Lock acquisition:
1. User A acquires a lock and makes some edits
2. User A walks away from computer
3. More than five minutes after User A's last edit, User B attempts to edit the page.  The logic determines that the lock has expired and gives the lock to User B
4. User A returns and attempts to make an edit, but then receives the "This edit session has expired" message.  They refresh and then see that User B has the resource locked. 

Scenario C: Locked
1. User A acquires a lock and makes some edits
2. User B attempts to edit the same resource but sees that the resource is locked by User A. 

