### PR TITLE
Fix to preserve backslash escapes in code blocks

### DIFF
--- a/src/main/java/edu/cmu/oli/content/AppUtils.java
+++ b/src/main/java/edu/cmu/oli/content/AppUtils.java
@@ -79,7 +79,8 @@ public class AppUtils {
         val = val.replaceAll("\\$", "!`!");
         val = val.replaceAll("&(?!.{2,4};)", "&amp;");
         for(String cd : cdataList){
-            val = val.replaceFirst("~~!", cd);
+            // AW: AUTHORING-2318 suppress processing regexp metachars in replacement.
+            val = val.replaceFirst("~~!", Matcher.quoteReplacement(cd));
         }
         val = val.replaceAll("!`!", "\\$");
         val = val.replaceAll("``!", "\n");


### PR DESCRIPTION
Deployed on shattrath for testing. 

The error was found to be introduced by the escapeAmpersand routine. This is used in one place to post-process the xml translation to escape ampersands occurring outside of CDATA sections. To skip CDATA sections the routine uses Java regexp machinery to find CDATA sections, temporarily replace them with marker strings while saving them on a list, do the ampersand escaping over the revised document, and then replace the marker strings with the saved CDATA sections to put them back. The problem was that the replaceFirst routine used to patch the CDATA's back in treats its argument as a regexp, interpreting metacharacters like backslash, leading to the behavior we see (": \t" in a code block gets changed to ": t"). Using Matcher.quoteReplacement on the replacement here fixes the problem. Should always be safe to quote the replacement so high confidence this doesn't break anything. 