### PR TITLE
Fix a dataset creation bug

### DIFF
--- a/src/main/resources/dataset/find-packages.sql
+++ b/src/main/resources/dataset/find-packages.sql
@@ -1,6 +1,8 @@
 # Query finds package guids for all previous versions of a package
 # identified by the package id and version
+# substitution code assumes one variable per line
 select distinct guid, id, version
 from content.package 
-where id = :packageId and version <= :packageVersion
+where id = :packageId
+and version <= :packageVersion
 order by date_created desc;


### PR DESCRIPTION
Fix a dataset creation bug where the code assumes one variable substitution per line in sql